### PR TITLE
werckerからプルリクエスト自動レビュー

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sgcop
 
-SonicGarden標準のrobocop設定支援をするツール
+SonicGarden標準のrubocop設定支援をするツール
 
 ## Installation
 
@@ -47,8 +47,8 @@ http://blog.onk.ninja/2015/10/27/rubocop-getting-started
 
 http://blog.onk.ninja/2015/10/27/rubocop-getting-started#治安の悪いアプリに-rubocop-を導入する
 
-### その他参考サイト
-- Rubcop チートシート http://qiita.com/kitaro_tn/items/abb881c098b3df3f9871
+### 参考サイト
+- Rubocop チートシート http://qiita.com/kitaro_tn/items/abb881c098b3df3f9871
 - 設定一覧(本家) https://github.com/bbatsov/rubocop/tree/master/config
 
 ### For atom editor user
@@ -60,6 +60,43 @@ Setting 内で Command の設定を
 
 に変更する。
 上記の設定をしないと gem になっていないので、 gem が見つかりませんというエラーになる。
+
+## werckerと組み合わせたプルリクエスト自動コメント
+
+werckerを利用している場合、wercker上でrubocopを実行して、その結果をプルリクエストにレビューコメントとして自動的に書き込むことができます。
+
+### werckerの設定方法
+
+1. Gemfile の `gem 'sgcop'` を test group に入れる
+
+2. このgemの [exe/run-rubocop.sh](https://github.com/SonicGarden/sgcop/tree/master/exe/run-rubocop.sh) をプロジェクトの bin/rubocop.sh にコピーし、実行権限を付加(`chmod +x`)
+（コピーしなくてもgem内のスクリプトを直接実行する方法があったら教えてください :pray:）
+3. .wercker.yml に以下の項目を追加
+
+**rubyのデフォルトエンコーディングをUTF-8に設定**
+（boxによってはいらないかも）
+```yml
+    - script:
+      name: set env
+      code: export RUBYOPT=-EUTF-8
+```
+
+**実行スクリプト**
+```yml
+    - script:
+      name: Run Rubocop and Report by Saddler
+      code: bin/run-rubocop.sh
+```
+
+4. GitHub の Personal Access Token でrepoのread/write権限をもったtokenを生成
+
+5. werckerの Application settings - Environment variables でそのtokenを `GITHUB_ACCESS_TOKEN` にprotectedでセット
+
+### サンプル(private repo)
+https://github.com/SonicGarden/ishuran/pull/57
+
+このように sg-bot にやらせたい場合はtokenを尋ねてください。
+
 
 ## Contributing
 

--- a/exe/run-rubocop.sh
+++ b/exe/run-rubocop.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -v
+if [ "${WERCKER_GIT_BRANCH}" != "master" ]; then
+  # Wercker
+
+  # Set current branch for ruby-saddler-reporter-support-git
+  export CURRENT_BRANCH=${WERCKER_GIT_BRANCH}
+
+  git diff -z --name-only origin/master \
+   | xargs -0 bundle exec rubocop-select
+
+  git diff -z --name-only origin/master \
+   | xargs -0 bundle exec rubocop-select \
+   | xargs bundle exec rubocop \
+       --require rubocop/formatter/checkstyle_formatter \
+       --format RuboCop::Formatter::CheckstyleFormatter
+
+  git diff -z --name-only origin/master \
+   | xargs -0 bundle exec rubocop-select \
+   | xargs bundle exec rubocop \
+       --require rubocop/formatter/checkstyle_formatter \
+       --format RuboCop::Formatter::CheckstyleFormatter \
+   | bundle exec checkstyle_filter-git diff origin/master
+
+  git diff -z --name-only origin/master \
+   | xargs -0 bundle exec rubocop-select \
+   | xargs bundle exec rubocop \
+       --require rubocop/formatter/checkstyle_formatter \
+       --format RuboCop::Formatter::CheckstyleFormatter \
+   | bundle exec checkstyle_filter-git diff origin/master \
+   | bundle exec saddler report \
+      --require saddler/reporter/github \
+      --reporter Saddler::Reporter::Github::PullRequestReviewComment
+fi
+exit 0

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", '~> 3.4'
-  spec.add_dependency 'rubocop', '~> 0.40'
+  spec.add_dependency 'rubocop', '~> 0.40.0'
   spec.add_dependency 'rubocop-rspec', '~> 1.5'
   spec.add_dependency 'rubocop-select'
   spec.add_dependency 'rubocop-checkstyle_formatter'

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -24,4 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", '~> 3.4'
   spec.add_dependency 'rubocop', '~> 0.40'
   spec.add_dependency 'rubocop-rspec', '~> 1.5'
+  spec.add_dependency 'rubocop-select'
+  spec.add_dependency 'rubocop-checkstyle_formatter'
+  spec.add_dependency 'checkstyle_filter-git'
+  spec.add_dependency 'saddler'
+  spec.add_dependency 'saddler-reporter-github'
 end


### PR DESCRIPTION
<img width="750" alt="2016-07-05 17 10 30" src="https://cloud.githubusercontent.com/assets/562433/16578068/7dc817f4-42d3-11e6-8cd1-240849f4b4dd.png">

sgcopにはほぼgemの依存を追加しただけです。

## werckerの設定方法

1. Gemfile の `group :test, :development` に `gem 'sgcop', github: 'SonicGarden/sgcop', branch: 'github-review'` を追加
（マージされれば `branch` は不要）
2. このgemの [exe/run-rubocop.sh](https://github.com/SonicGarden/sgcop/blob/842c97feb69fa90d45d271b45bc1f6492af4aa85/exe/run-rubocop.sh) をプロジェクトの bin/rubocop.sh にコピーし、実行権限を付加(chmod +x)

3. .wercker.yml に以下の項目を追加

なぜか僕の場合このUTF-8設定が必要だったけど、boxによってはいらないかも。
```yml
    - script:
      name: set env
      code: export RUBYOPT=-EUTF-8
```

実行スクリプト
```yml
    - script:
      name: Run Rubocop and Report by Saddler
      code: bin/run-rubocop.sh
```

_4. GitHub の Personal Access Token でプロジェクトrepoのread/write権限をもったtokenを生成

_5. werckerの Application settings - Environment variables にそのtokenをprotectedでセット
`GITHUB_ACCESS_TOKEN=xxx`

サンプル（SG内部）
https://github.com/SonicGarden/ishuran/pull/57
このように sg-bot にやらせたい場合はtokenを聞いてください

gem内の exe/run-rubocop.sh をそのまま実行する方法を模索しましたがうまくいきませんでした。知ってたら教えてください〜 🙏 
