### PR TITLE
Update dependencies

### DIFF
--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", '~> 3.4'
-  spec.add_dependency 'rubocop', '~> 0.45.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.8.0'
+  spec.add_dependency 'rubocop', '~> 0.48.1'
+  spec.add_dependency 'rubocop-rspec', '~> 1.15.1'
   spec.add_dependency 'rubocop-select'
   spec.add_dependency 'rubocop-checkstyle_formatter'
   spec.add_dependency 'checkstyle_filter-git'


### PR DESCRIPTION
rubocop, rubocop-rspec の依存バージョンを最新に更新。
バージョン指定しないとまずいのかな？