### PR TITLE
[review] haml-lint を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Sgcop
 
-SonicGarden標準のrubocop設定支援をするツール
+SonicGarden標準の rubocop, haml-lint 設定支援をするツール
 
 ## Installation
+
+RubyGems.org にリリースしていないgemのため、specific_install gem を使ってインストールする。
+```
+$ gem install specific_install
+$ gem specific_install SonicGarden/sgcop
+```
+
+bundler を使用する場合（非推奨）
 
 ```ruby
 gem 'sgcop', github: 'SonicGarden/sgcop'
@@ -17,35 +25,37 @@ development の group に入れると、デプロイ時にgemを参照できな�
 gem 'sgcop', github: 'SonicGarden/sgcop', require: false
 ````
 
-### RubyMine
-RubyMine 2017.1 から標準のコード解析機能で rubocop が使えるようになっているが、 bundler を使わずに実行されるため、 `gem 'sgcop', github: ...`  形式でインストールされた sgcop が使用できない。
-specific_install gem を使って、グローバルな gem として sgcop をインストールすれば使えるようになる。
-
-```
-$ gem install specific_install
-$ gem specific_install SonicGarden/sgcop
-```
 
 ## Usage
 
-For non-Rails projects, add the following to the top of your .rubocop.yml file:
+SonicGarden標準スタイルを用意しています。
+
+プロジェクトルートに .rubocop.yml ファイルをつくり、Railsではないプロジェクトの場合は以下のように書く。
 
 ```
 inherit_gem:
   sgcop: ruby/rubocop.yml
 ```
 
-If your project is a Rails project, you should use the instruction below, which includes all the standard SonicGarden Ruby styles, with Rails-specific cops:
+Railsプロジェクトの場合は以下のように書く。
 
 ```
 inherit_gem:
   sgcop: rails/rubocop.yml
 ```
 
-And then execute:
+そして実行。
 
 ```
 rubocop <options...>
+```
+
+haml-lintは inherit_gem に相当する機能がないため、プロジェクトルートに .haml-lint.yml ファイルをつくり、このgemの [haml/haml-lint.yml](https://github.com/SonicGarden/sgcop/tree/master/haml/haml-lint.yml) をコピーする。
+
+そして実行。
+
+```
+haml-lint app/views/
 ```
 
 ## しつけ方
@@ -62,7 +72,7 @@ http://blog.onk.ninja/2015/10/27/rubocop-getting-started#治安の悪いアプ�
 
 ### For atom editor user
 
-linter-rubocop https://atom.io/packages/linter-rubocop のパッケージをインストールする
+bundleを使ってインストールしている場合、 [linter-rubocop](https://atom.io/packages/linter-rubocop) のパッケージをインストールする
 Setting 内で Command の設定を
 
     bundle exec rubocop
@@ -70,17 +80,28 @@ Setting 内で Command の設定を
 に変更する。
 上記の設定をしないと gem になっていないので、 gem が見つかりませんというエラーになる。
 
-## werckerと組み合わせたプルリクエスト自動コメント
+## CircleCI/Werckerと組み合わせたプルリクエスト自動レビューコメント
 
-werckerを利用している場合、wercker上でrubocopを実行して、その結果をプルリクエストにレビューコメントとして自動的に書き込むことができます。
+CIを利用している場合、CI上でrubocopとhaml-lintを実行して、その結果をプルリクエストにレビューコメントとして自動的に書き込むことができます。
 
-### werckerの設定方法
+### 実行スクリプトの設定
 
-1. Gemfile の `gem 'sgcop'` を test group に入れる
+このgemの [exe/run-rubocop.sh](https://github.com/SonicGarden/sgcop/tree/master/exe/run-rubocop.sh) をプロジェクトの bin/rubocop.sh にコピーし、実行権限を付加(`chmod +x`)します。
 
-2. このgemの [exe/run-rubocop.sh](https://github.com/SonicGarden/sgcop/tree/master/exe/run-rubocop.sh) をプロジェクトの bin/rubocop.sh にコピーし、実行権限を付加(`chmod +x`)
-（コピーしなくてもgem内のスクリプトを直接実行する方法があったら教えてください :pray:）
-3. .wercker.yml に以下の項目を追加
+CIの設定に以下の項目を追加します。
+
+#### CircleCIの場合
+設定ファイルは circle.yml
+
+**実行スクリプト**
+```yml
+test:
+  post:
+    - bin/run-rubocop.sh
+```
+
+#### Werckerの場合
+設定ファイルは .wercker.yml
 
 **rubyのデフォルトエンコーディングをUTF-8に設定**
 （boxによってはいらないかも）
@@ -97,14 +118,17 @@ werckerを利用している場合、wercker上でrubocopを実行して、そ�
       code: bin/run-rubocop.sh
 ```
 
-4. GitHub の Personal Access Token でrepoのread/write権限をもったtokenを生成
+### トークンの設定
 
-5. werckerの Application settings - Environment variables でそのtokenを `GITHUB_ACCESS_TOKEN` にprotectedでセット
+そして、 GitHub の Personal Access Token でrepoのread/write権限をもったtokenを生成して、
+CIの環境設定からそのtokenを `GITHUB_ACCESS_TOKEN` という名前でセットしてください。
+
+Werckerの場合、Protected Variables としてセットしてください。
 
 ### サンプル(private repo)
 https://github.com/SonicGarden/ishuran/pull/57
 
-このように sg-bot にやらせたい場合はtokenを尋ねてください。
+このように sg-bot にやらせたい場合は sg-bot のtokenをremottyなどで尋ねてください。
 
 
 ## Contributing

--- a/exe/run-rubocop.sh
+++ b/exe/run-rubocop.sh
@@ -1,35 +1,62 @@
 #!/bin/bash
 set -v
-if [ "${WERCKER_GIT_BRANCH}" != "master" ]; then
-  # Wercker
+export OCTOKIT_AUTO_PAGINATE=true
 
-  # Set current branch for ruby-saddler-reporter-support-git
-  export CURRENT_BRANCH=${WERCKER_GIT_BRANCH}
+report() {
+  gem install --no-document specific_install
+  gem specific_install https://github.com/SonicGarden/sgcop.git # now we can not specify fixed version
+  # gem install --no-document rubocop -v '0.49.1'
+  # gem install --no-document haml_lint -v '0.26.0'
+  gem install --no-document rubocop-select rubocop-checkstyle_formatter \
+              checkstyle_filter-git saddler saddler-reporter-github
 
+  # For display
   git diff -z --name-only origin/master \
-   | xargs -0 bundle exec rubocop-select
-
-  git diff -z --name-only origin/master \
-   | xargs -0 bundle exec rubocop-select \
-   | xargs bundle exec rubocop \
-       --require rubocop/formatter/checkstyle_formatter \
-       --format RuboCop::Formatter::CheckstyleFormatter
-
-  git diff -z --name-only origin/master \
-   | xargs -0 bundle exec rubocop-select \
-   | xargs bundle exec rubocop \
+   | xargs -0 rubocop-select \
+   | xargs rubocop \
        --require rubocop/formatter/checkstyle_formatter \
        --format RuboCop::Formatter::CheckstyleFormatter \
-   | bundle exec checkstyle_filter-git diff origin/master
+   | checkstyle_filter-git diff origin/master \
+   | xmllint --format -
 
+  git diff -z --diff-filter=d --name-only origin/master \
+   | grep -e '\.haml$' \
+   | xargs haml-lint --reporter checkstyle \
+   | checkstyle_filter-git diff origin/master \
+   | xmllint --format -
+
+  # Reporting
   git diff -z --name-only origin/master \
-   | xargs -0 bundle exec rubocop-select \
-   | xargs bundle exec rubocop \
+   | xargs -0 rubocop-select \
+   | xargs rubocop \
        --require rubocop/formatter/checkstyle_formatter \
        --format RuboCop::Formatter::CheckstyleFormatter \
-   | bundle exec checkstyle_filter-git diff origin/master \
-   | bundle exec saddler report \
+   | checkstyle_filter-git diff origin/master \
+   | saddler report \
       --require saddler/reporter/github \
       --reporter Saddler::Reporter::Github::PullRequestReviewComment
+
+  git diff -z --diff-filter=d --name-only origin/master \
+   | grep -e '\.haml$' \
+   | xargs haml-lint --reporter checkstyle \
+   | checkstyle_filter-git diff origin/master \
+   | saddler report \
+      --require saddler/reporter/github \
+      --reporter Saddler::Reporter::Github::PullRequestReviewComment
+}
+
+if [ -n "${CIRCLECI}" ]; then
+  # CircleCI
+  if [ "${CIRCLE_BRANCH}" != "master" ]; then
+    report
+  fi
+elif [ -n "${WERCKER_ROOT}" ]; then
+  # Wercker
+  if [ "${WERCKER_GIT_BRANCH}" != "master" ]; then
+    # Set current branch for ruby-saddler-reporter-support-git
+    export CURRENT_BRANCH=${WERCKER_GIT_BRANCH}
+    report
+  fi
 fi
+
 exit 0

--- a/exe/run-rubocop.sh
+++ b/exe/run-rubocop.sh
@@ -16,14 +16,12 @@ report() {
    | xargs rubocop \
        --require rubocop/formatter/checkstyle_formatter \
        --format RuboCop::Formatter::CheckstyleFormatter \
-   | checkstyle_filter-git diff origin/master \
-   | xmllint --format -
+   | checkstyle_filter-git diff origin/master
 
   git diff -z --diff-filter=d --name-only origin/master \
    | grep -e '\.haml$' \
    | xargs haml-lint --reporter checkstyle \
-   | checkstyle_filter-git diff origin/master \
-   | xmllint --format -
+   | checkstyle_filter-git diff origin/master
 
   # Reporting
   git diff -z --name-only origin/master \

--- a/haml/haml-lint.yml
+++ b/haml/haml-lint.yml
@@ -1,0 +1,52 @@
+# target_version:
+# haml-lint v0.26.0
+
+linters:
+  # クラスとIDはどちらから書いてもよい
+  ClassesBeforeIds:
+    enabled: false
+
+  # コメントアウト時など、連続行のコメントは許可
+  ConsecutiveComments:
+    enabled: false
+
+  # エディタによってはコメントアウト時にスペースがつかないことがあるので
+  # コメント後のスペースはなくてもよい
+  LeadingCommentSpace:
+    enabled: false
+
+  # 1行の文字数
+  LineLength:
+    max: 160
+
+  # rubyコードはrubocopでチェックする
+  RuboCop:
+    enabled: true
+    # These cops are incredibly noisy when it comes to HAML templates, so we
+    # ignore them.
+    ignored_cops:
+      - Lint/BlockAlignment
+      - Lint/EndAlignment
+      - Lint/Void
+      - Layout/AlignParameters
+      - Layout/IndentationWidth
+      # エディタによってはコメントアウト時にスペースがつかないことがあるため
+      # コメント後のスペースは制限しない
+      - Layout/LeadingCommentSpace
+      - Layout/TrailingBlankLines
+      - Layout/TrailingWhitespace
+      - Metrics/BlockLength
+      - Metrics/LineLength
+      - Style/BlockNesting
+      - Style/ElseAlignment
+      - Style/EndOfLine
+      - Style/FileName
+      - Style/FinalNewline
+      - Style/FrozenStringLiteralComment
+      - Style/IfUnlessModifier
+      - Style/Next
+      - Style/WhileUntilModifier
+
+  # Hash属性の内側にスペースはなくてもよい
+  SpaceInsideHashAttributes:
+    enabled: false

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -6,6 +6,9 @@
 # - 名前がわからないと disable コメントも書けない
 AllCops:
   DisplayCopNames: true
+  DisplayStyleGuide: true
+  StyleGuideBaseURL: https://github.com/fortissimo1997/ruby-style-guide/blob/japanese/README.ja.md
+  ExtraDetails: true
 
 # ============================================================
 # Style

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -24,9 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", '~> 3.4'
   spec.add_dependency 'rubocop', '~> 0.49.1'
   spec.add_dependency 'rubocop-rspec', '~> 1.15.1'
-  spec.add_dependency 'rubocop-select'
-  spec.add_dependency 'rubocop-checkstyle_formatter'
-  spec.add_dependency 'checkstyle_filter-git'
-  spec.add_dependency 'saddler'
-  spec.add_dependency 'saddler-reporter-github'
+  spec.add_dependency 'haml_lint', '~> 0.26.0'
 end


### PR DESCRIPTION
haml-lintを追加しました。
haml-lintはrubocopと連携して、hamlの中のrubyコードをrubocopでチェックしてくれます。もちろんhaml自体もチェックします。
https://github.com/brigade/haml-lint

ついでにプルリクエスト自動レビューをWerckerとCircleCIどちらでも動くように書き直しました。rubocopとhaml-lint両方が動きます。
あとインストール方法を specific_install 推奨としています。