### PR TITLE
[review] コマンドのオプションが間違っていたので修正

### DIFF
--- a/exe/run-rubocop.sh
+++ b/exe/run-rubocop.sh
@@ -11,20 +11,20 @@ report() {
               checkstyle_filter-git saddler saddler-reporter-github
 
   # For display
-  git diff -z --name-only origin/master \
+  git diff -z --diff-filter=d --name-only origin/master \
    | xargs -0 rubocop-select \
    | xargs rubocop \
        --require rubocop/formatter/checkstyle_formatter \
        --format RuboCop::Formatter::CheckstyleFormatter \
    | checkstyle_filter-git diff origin/master
 
-  git diff -z --diff-filter=d --name-only origin/master \
+  git diff --diff-filter=d --name-only origin/master \
    | grep -e '\.haml$' \
    | xargs haml-lint --reporter checkstyle \
    | checkstyle_filter-git diff origin/master
 
   # Reporting
-  git diff -z --name-only origin/master \
+  git diff -z --diff-filter=d --name-only origin/master \
    | xargs -0 rubocop-select \
    | xargs rubocop \
        --require rubocop/formatter/checkstyle_formatter \
@@ -34,7 +34,7 @@ report() {
       --require saddler/reporter/github \
       --reporter Saddler::Reporter::Github::PullRequestReviewComment
 
-  git diff -z --diff-filter=d --name-only origin/master \
+  git diff --diff-filter=d --name-only origin/master \
    | grep -e '\.haml$' \
    | xargs haml-lint --reporter checkstyle \
    | checkstyle_filter-git diff origin/master \


### PR DESCRIPTION
本体は何も変わっていないので、リリースはしなくていいと思います。

【説明】
`--diff-filter=d` ：削除されたファイルを除く
削除されたファイルにはコメントできないため除きます。

`-z` ：ファイル名のセパレータを改行の代わりにNUL文字にする
xargs は `-0` で処理できるのだが grep はできないため、grepに渡しているところは `-z` をつけないようにします。