### PR TITLE
[review] PredicateName部分の表記を最新のものに

### DIFF
--- a/lib/sgcop/version.rb
+++ b/lib/sgcop/version.rb
@@ -1,3 +1,3 @@
 module Sgcop
-  VERSION = '0.0.20'.freeze
+  VERSION = '0.0.21'.freeze
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -85,13 +85,13 @@ Style/PerlBackrefs:
   AutoCorrect: false
 
 # has_ から始まるメソッドは許可する
-Style/PredicateName:
+Naming/PredicateName:
   NamePrefixBlacklist:
-    - "is_"
-    - "have_"
+    - is_
+    - have_
   NamePrefix:
-    - "is_"
-    - "have_"
+    - is_
+    - have_
 
 # ローカル変数とメソッド呼び出しの区別をつけた方が分かりやすい場合が多い
 Style/RedundantSelf:

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", '~> 3.4'
-  spec.add_dependency 'rubocop', '~> 0.49.1'
-  spec.add_dependency 'rubocop-rspec', '~> 1.15.1'
-  spec.add_dependency 'haml_lint', '~> 0.26.0'
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rspec", '~> 3.7'
+  spec.add_dependency 'rubocop', '~> 0.52.0'
+  spec.add_dependency 'rubocop-rspec', '~> 1.20.1'
+  spec.add_dependency 'haml_lint', '~> 0.27.0'
 end


### PR DESCRIPTION
Style -> Naming に変更されている
https://rubocop.readthedocs.io/en/latest/cops_naming/#namingpredicatename

各要素もダブルコーテーションで囲わずに表記するみたい
https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L664