### PR TITLE
[review] Contextの条件の説明を日本語でも書きたいので、RSpec/ContextWordingを無効化

### DIFF
--- a/lib/sgcop/version.rb
+++ b/lib/sgcop/version.rb
@@ -1,3 +1,3 @@
 module Sgcop
-  VERSION = '0.0.21'.freeze
+  VERSION = '0.0.22'.freeze
 end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -63,6 +63,10 @@ Style/EmptyMethod:
 RSpec/AnyInstance:
   Enabled: false
 
+# Contextの条件の説明を日本語でも書きたいので
+RSpec/ContextWording:
+ Enabled: false
+
 # 以下のようなもので引っかかってしまって困るので
 # describe GuestTicket do
 #   describe '#save' do


### PR DESCRIPTION
このようなエラーがでるようになったのでPRしてみました。
```
 C: RSpec/ContextWording: Start context description with 'when', 'with', or 'without'. (http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording)
        context '始期日が1日の場合' do
```

以下の無効化対応
https://github.com/backus/rubocop-rspec/blob/master/config/default.yml#L46

