### PR TITLE
依存パッケージを最新版に更新してバージョンを0.0.26に

### DIFF
--- a/lib/sgcop/version.rb
+++ b/lib/sgcop/version.rb
@@ -1,3 +1,3 @@
 module Sgcop
-  VERSION = '0.0.25'.freeze
+  VERSION = '0.0.26'.freeze
 end

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "rspec", '~> 3.7'
-  spec.add_dependency 'rubocop', '~> 0.57.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.26.0'
+  spec.add_development_dependency "rspec", '~> 3.8'
+  spec.add_dependency 'rubocop', '~> 0.58.0'
+  spec.add_dependency 'rubocop-rspec', '~> 1.28.0'
   spec.add_dependency 'haml_lint', '~> 0.28.0'
   spec.add_dependency 'brakeman'
   spec.add_dependency 'brakeman_translate_checkstyle_format'


### PR DESCRIPTION
rubocopのバージョンが古くて動かなかったので他のgem含めて最新のバージョンに変更しました。