### PR TITLE
[review]MethodLength系のrubocop設定にCountAsOneを追加

### DIFF
--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -73,12 +73,26 @@ Metrics/BlockLength:
     - "config/routes.rb"
     - "spec/**/*"
     - "db/migrate/*"
+  # 要素を縦に並べるのは可読性のためなので実行数が増えても許容する
+  CountAsOne: ['array', 'hash', 'method_call']
 
-# migratonは致し方ない
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmethodlength
 Metrics/MethodLength:
+  # migratonは致し方ない
   Exclude:
     - "db/migrate/*"
+  # 要素を縦に並べるのは可読性のためなので実行数が増えても許容する
+  CountAsOne: ['array', 'hash', 'method_call']
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength
+Metrics/ClassLength:
+  # 要素を縦に並べるのは可読性のためなので実行数が増えても許容する
+  CountAsOne: ['array', 'hash', 'method_call']
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength
+Metrics/ModuleLength:
+  # 要素を縦に並べるのは可読性のためなので実行数が増えても許容する
+  CountAsOne: ['array', 'hash', 'method_call']
 
 # migratonは致し方ない
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize


### PR DESCRIPTION
- 可読性を上げるために配列などの要素を縦に並べた際、それをMethodLengthで指摘するのは無意味なのでCountAsOneを設定しました。
  - CountAsOneには「ヒアドキュメントを全体を1行としてカウントする」というオプションもありますが、そっちは意味合いが少し違う気がして、組み込んでいません。
- マージ前のPRが残っていたので、一旦VERSIONをいじらずにPRを飛ばしています。