### PR TITLE
[review] 0.10.11

### DIFF
--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -434,6 +434,9 @@ Rails/SelectMap: # new in 2.21
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsunusedrendercontent
 Rails/UnusedRenderContent: # new in 2.21
   Enabled: true
+# https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsenvlocal
+Rails/EnvLocal: # new in 2.22
+  Enabled: true
 
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecidenticalequalityassertion
 RSpec/IdenticalEqualityAssertion: # (new in 2.4)

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -493,6 +493,7 @@ Layout/FirstArrayElementIndentation:
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
 Layout/LineLength:
   Max: 160
+  AllowedPatterns: ["^ *#"]
 
 # 複数行に渡る Hash では、一行に複数のキーを入れてはならない
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilinehashkeylinebreaks

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-capybara', '~> 2.19.0'
   spec.add_dependency 'rubocop-factory_bot', '~> 2.24.0'
   spec.add_dependency 'rubocop-performance', '~> 1.19.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.21.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.22.1'
   spec.add_dependency 'rubocop-rake', '~> 0.6.0'
-  spec.add_dependency 'rubocop-rspec', '~> 2.24.0'
+  spec.add_dependency 'rubocop-rspec', '~> 2.25.0'
 end


### PR DESCRIPTION
- rubocop-rails@2.22.1, rubocop-rspec@2.25.0
- コメント行の文字数チェックは不要