### PR TITLE
[review] SpecStabilityCheckの対象追加

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -249,6 +249,7 @@ Sgcop/Capybara/SpecStabilityCheck:
     - assert_no_emails
     - assert_enqueued_jobs
     - capture_emails
+    - expect
   WaitMatchers:
     - have_content
     - have_text

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -149,6 +149,10 @@ Style/MethodCallWithArgsParentheses:
 Style/Send:
   Enabled: true
 
+Style/BlockDelimiters:
+  AutoCorrect: true
+  EnforcedStyle: braces_for_chaining
+
 # rubocop 本体でまだデフォルト設定がPendingのルールの有効・無効設定
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintduplicateregexpcharacterclasselement
 Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)


### PR DESCRIPTION
以下みたいなケースを検出可能に

```ruby
expect {
  click_button 'インポート'
}.to change(User, :count).by(2)
expect(page).to have_content('インポートが完了しました')
```