### PR TITLE
[review] fix: avoid false positives in HashFetchDefault for non-Hash `[]` access

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -171,6 +171,7 @@ Sgcop/ErrorMessageFormat:
 Sgcop/HashFetchDefault:
   Description: "Hash#fetchを使用してデフォルト値を扱うことでfalseyな値を保持しよう"
   Enabled: true
+  SafeAutoCorrect: false
   Reference:
     - https://rubystyle.guide/#hash-fetch-defaults
 

--- a/lib/rubocop/cop/sgcop/hash_fetch_default.rb
+++ b/lib/rubocop/cop/sgcop/hash_fetch_default.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = 'Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.'
 
         def_node_matcher :hash_element_access, <<~PATTERN
-          (send $_ :[] $_)
+          (send $_ :[] ${sym str nil true false})
         PATTERN
 
         def on_or(node)

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.85.0'
-  spec.add_dependency 'rubocop-capybara', '~> 2.22.0'
+  spec.add_dependency 'rubocop', '~> 1.86.1'
+  spec.add_dependency 'rubocop-capybara', '~> 2.23.0'
   spec.add_dependency 'rubocop-factory_bot', '~> 2.28.0'
   spec.add_dependency 'rubocop-performance', '~> 1.26.0'
   spec.add_dependency 'rubocop-rails', '~> 2.34.2'

--- a/spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb
+++ b/spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb
@@ -64,4 +64,34 @@ describe RuboCop::Cop::Sgcop::HashFetchDefault do
       batman.fetch(:is_evil, true)
     RUBY
   end
+
+  it 'does not register an offense for integer index access (likely Array/String)' do
+    expect_no_offenses(<<~RUBY)
+      array[0] || "default"
+    RUBY
+  end
+
+  it 'does not register an offense for range access (likely String/Array slice)' do
+    expect_no_offenses(<<~RUBY)
+      str[0..3] || "default"
+    RUBY
+  end
+
+  it 'does not register an offense for multi-argument access (likely String#[])' do
+    expect_no_offenses(<<~RUBY)
+      str[0, 3] || "default"
+    RUBY
+  end
+
+  it 'does not register an offense for variable key access (cannot tell if it is a Hash)' do
+    expect_no_offenses(<<~RUBY)
+      obj[index] || "default"
+    RUBY
+  end
+
+  it 'does not register an offense for method call key access' do
+    expect_no_offenses(<<~RUBY)
+      obj[key_method] || "default"
+    RUBY
+  end
 end


### PR DESCRIPTION
## 背景・課題

`Sgcop/HashFetchDefault` は `obj[key] || default` を `obj.fetch(key, default)` に書き換える Cop だが、AST マッチングが「`[]` を呼ぶ式すべて」を対象にしていたため、Hash 以外（String / Array / MatchData / Redis クライアント等）の `[]` アクセスまで誤検知して書き換えてしまう問題があった。

特に `Array#fetch` や `MatchData#fetch` は **メソッド自体は存在するが要素が無いと `IndexError` を投げる別物** なので、自動修正が走るとランタイム挙動が壊れるリスクがあった。利用側ではこの Cop を一時的に無効化していた。

## 変更内容

### `lib/rubocop/cop/sgcop/hash_fetch_default.rb`

ノードマッチャを「Hash アクセスらしいリテラルキーのみ」に絞り込み。パターンは `(send $_ :[] ${sym str nil true false})` に変更した。

- 検知する: `h[:key]` / `h["key"]` / `h[nil]` / `h[true]` / `h[false]`
- 検知しない: `arr[0]` / `str[0..3]` / `str[0, 3]` / `obj[var]` / `obj[method_call]`

整数・Range・複数引数・変数・メソッド呼び出しのキーは Hash 用途と判定できないため、保守的に対象外とした。

### `config/default.yml`

`Sgcop/HashFetchDefault` に `SafeAutoCorrect: false` を追加。  
すり抜けた誤検知が `rubocop -a` で破壊的に書き換えられないよう保険をかけ、`-A`（unsafe）でしか自動修正しないようにした。

### `spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb`

回帰テストとして「整数インデックス」「Range」「複数引数」「変数キー」「メソッド呼び出しキー」の 5 ケースで `expect_no_offenses` を追加。

### `sgcop.gemspec`

依存バージョンを更新（本 PR の本質的な修正とは独立）。

- `rubocop` `~> 1.85.0` → `~> 1.86.1`
- `rubocop-capybara` `~> 2.22.0` → `~> 2.23.0`

## レビューのポイント

- **取りこぼしと誤検知のトレードオフ**: 変数キー（`h[k]`）も検知対象から外している。Hash アクセスとして正当なケースも一部見逃すが、`||` 由来のバグ防止という目的では「過検知より見逃し」の方が安全という判断。この方針で良いか確認お願いします。
- **`SafeAutoCorrect: false` の影響**: 利用プロジェクトで `rubocop -a` を CI などに組み込んでいる場合、本 Cop の自動修正は走らなくなり警告のみになる。意図通り。
- **依存更新の同梱**: `rubocop` / `rubocop-capybara` のマイナー更新が同じ PR に含まれている。本来は別 PR が望ましいが影響範囲が小さければそのままでも可。
