### PR TITLE
[review] feat: have_enqueued_mail マッチャーの使用を防ぐ

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sgcopが提供するカスタムCopの一覧です。
 
 | Cop名 | 説明 | デフォルト |
 |-------|------|:----------:|
-| [`Sgcop/RSpec/ActionMailerTestHelper`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/rspec/action_mailer_test_helper.rb) | ActionMailerテストヘルパーの適切な使用を確認 | ❌ |
+| [`Sgcop/RSpec/ActionMailerTestHelper`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/rspec/action_mailer_test_helper.rb) | ActionMailer::Base.deliveriesやhave_enqueued_mailの代わりにActionMailer::TestHelperの適切な使用を確認 | ❌ |
 | [`Sgcop/RSpec/ActiveJobTestHelper`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/rspec/active_job_test_helper.rb) | RSpecのActiveJobマッチャーの代わりにActiveJob::TestHelperのメソッド使用を推奨 | ❌ |
 | [`Sgcop/RSpec/ConditionalExample`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/rspec/conditional_example.rb) | 条件付きexpectを避け、常に無条件でアサーションを行うことを推奨 | ✅ |
 | [`Sgcop/RSpec/RedundantLetReference`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/rspec/redundant_let_reference.rb) | letを参照するだけの無意味な処理を検出し、let!の使用や直接セットアップを推奨 | ✅ |

--- a/config/default.yml
+++ b/config/default.yml
@@ -176,12 +176,13 @@ Sgcop/HashFetchDefault:
     - https://rubystyle.guide/#hash-fetch-defaults
 
 Sgcop/Rspec/ActionMailerTestHelper:
-  Description: "ActionMailer::Base.deliveriesの代わりにActionMailer::TestHelperのメソッドを使用しよう"
+  Description: "ActionMailer::Base.deliveriesやhave_enqueued_mailの代わりにActionMailer::TestHelperのメソッドを使用しよう"
   Enabled: false
   Include:
     - "spec/**/*_spec.rb"
   Reference:
     - https://api.rubyonrails.org/classes/ActionMailer/TestHelper.html
+    - https://rspec.info/features/6-0/rspec-rails/matchers/have-enqueued-mail-matcher/
 
 Sgcop/Rspec/ActiveJobTestHelper:
   Description: "RSpecのActiveJobマッチャーの代わりにActiveJob::TestHelperのメソッドを使用しよう"

--- a/lib/rubocop/cop/sgcop/rspec/action_mailer_test_helper.rb
+++ b/lib/rubocop/cop/sgcop/rspec/action_mailer_test_helper.rb
@@ -10,6 +10,8 @@ module RuboCop
           MSG_EMPTY = 'Use `assert_no_emails` instead of ActionMailer::Base.deliveries.empty?.'
           MSG_ANY = 'Use `assert_emails` to verify emails were sent instead of ActionMailer::Base.deliveries.any?.'
           MSG_ACCESS = 'Use `capture_emails { ... }` to access sent emails instead of ActionMailer::Base.deliveries.%<method>s.'
+          MSG_HAVE_ENQUEUED_MAIL = 'Use `assert_enqueued_email_with`, `assert_enqueued_emails(count)`, ' \
+                                   'or `assert_no_enqueued_emails` instead of `have_enqueued_mail`.'
 
           def_node_matcher :deliveries_call?, <<~PATTERN
             (send
@@ -31,11 +33,17 @@ module RuboCop
                   (const nil? :ActionMailer) :Base) :deliveries) :[] ...)
           PATTERN
 
+          def_node_matcher :have_enqueued_mail_matcher?, <<~PATTERN
+            (send nil? :have_enqueued_mail ...)
+          PATTERN
+
           def on_send(node)
             if deliveries_call?(node) && !node.parent&.send_type?
               add_offense(node, message: MSG)
             elsif deliveries_method_call?(node)
               check_deliveries_method(node)
+            elsif have_enqueued_mail_matcher?(node)
+              add_offense(node, message: MSG_HAVE_ENQUEUED_MAIL)
             end
           end
 

--- a/spec/rubocop/cop/sgcop/rspec/action_mailer_test_helper_spec.rb
+++ b/spec/rubocop/cop/sgcop/rspec/action_mailer_test_helper_spec.rb
@@ -73,5 +73,39 @@ describe RuboCop::Cop::Sgcop::Rspec::ActionMailerTestHelper do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Rspec/ActionMailerTestHelper: Use ActionMailer::TestHelper methods instead of ActionMailer::Base.deliveries.
       RUBY
     end
+
+    it 'registers an offense for have_enqueued_mail matcher' do
+      expect_offense(<<~RUBY, 'spec/models/user_spec.rb')
+        expect { User.create }.to have_enqueued_mail(UserMailer, :welcome)
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Rspec/ActionMailerTestHelper: Use `assert_enqueued_email_with`, `assert_enqueued_emails(count)`, or `assert_no_enqueued_emails` instead of `have_enqueued_mail`.
+      RUBY
+    end
+
+    it 'registers an offense for have_enqueued_mail with chained .with' do
+      expect_offense(<<~RUBY, 'spec/models/user_spec.rb')
+        expect { User.create }.to have_enqueued_mail(UserMailer, :welcome).with(user_id: 1)
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Rspec/ActionMailerTestHelper: Use `assert_enqueued_email_with`, `assert_enqueued_emails(count)`, or `assert_no_enqueued_emails` instead of `have_enqueued_mail`.
+      RUBY
+    end
+
+    it 'registers an offense for have_enqueued_mail with not_to' do
+      expect_offense(<<~RUBY, 'spec/models/user_spec.rb')
+        expect { User.create }.not_to have_enqueued_mail(UserMailer, :welcome)
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Rspec/ActionMailerTestHelper: Use `assert_enqueued_email_with`, `assert_enqueued_emails(count)`, or `assert_no_enqueued_emails` instead of `have_enqueued_mail`.
+      RUBY
+    end
+
+    it 'registers an offense for have_enqueued_mail with to_not' do
+      expect_offense(<<~RUBY, 'spec/models/user_spec.rb')
+        expect { User.create }.to_not have_enqueued_mail(UserMailer, :welcome)
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Rspec/ActionMailerTestHelper: Use `assert_enqueued_email_with`, `assert_enqueued_emails(count)`, or `assert_no_enqueued_emails` instead of `have_enqueued_mail`.
+      RUBY
+    end
+
+    it 'does not register an offense for assert_enqueued_email_with' do
+      expect_no_offenses(<<~RUBY, 'spec/models/user_spec.rb')
+        assert_enqueued_email_with(UserMailer, :welcome) { User.create }
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Sgcop/Rspec/ActionMailerTestHelper` Cop を拡張し、rspec-rails の `have_enqueued_mail` マッチャーを検出するようにした
- 代替として `assert_enqueued_email_with` / `assert_enqueued_emails(count)` / `assert_no_enqueued_emails` を提示
- README、config/default.yml、spec を併せて更新

## Test plan

- [x] `bundle exec rspec spec/rubocop/cop/sgcop/rspec/action_mailer_test_helper_spec.rb` がパス（追加 5 例含む 15 例すべて成功）
- [x] `bundle exec rspec` 全件パス（358 例）
- [x] `bundle exec rubocop` を変更ファイル限定で実行し違反なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)