### PR TITLE
[review] Update rubocop-rails dependency and version number

### DIFF
--- a/lib/sgcop/version.rb
+++ b/lib/sgcop/version.rb
@@ -1,3 +1,3 @@
 module Sgcop
-  VERSION = '1.26.7'.freeze
+  VERSION = '1.26.8'.freeze
 end

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-capybara', '~> 2.23.0'
   spec.add_dependency 'rubocop-factory_bot', '~> 2.28.0'
   spec.add_dependency 'rubocop-performance', '~> 1.26.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.34.2'
+  spec.add_dependency 'rubocop-rails', '~> 2.35.2'
   spec.add_dependency 'rubocop-rake', '~> 0.7.1'
   spec.add_dependency 'rubocop-rspec', '~> 3.9.0'
   spec.add_dependency 'rubocop-rspec_rails', '~> 2.32.0'


### PR DESCRIPTION
Update the rubocop-rails dependency to version 2.35.2 and increment the gem version to 1.26.8.