### PR TITLE
[review] fix: support i18n lazy lookup for component erb templates

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -292,7 +292,7 @@ Sgcop/I18nLazyLookup:
   Include:
     - "app/controllers/**/*.rb"
     - "app/views/**/*"
-    - "app/components/**/*.rb"
+    - "app/components/**/*"
   Reference:
     - https://guides.rubyonrails.org/i18n.html#lazy-lookup
 

--- a/lib/rubocop/cop/sgcop/i18n_lazy_lookup.rb
+++ b/lib/rubocop/cop/sgcop/i18n_lazy_lookup.rb
@@ -101,7 +101,7 @@ module RuboCop
 
           # Check for components
           if file_path.include?('app/components/')
-            return detect_component_context(node)
+            return detect_component_context(node, file_path)
           end
 
           # Check for controllers
@@ -120,15 +120,17 @@ module RuboCop
 
         def detect_view_context(_node, file_path)
           # Extract view path like "books/index" from "app/views/books/index.html.erb"
-          match = file_path.match(%r{app/views/(.+?)(?:\.[^/]+)*$})
-          return unless match
-
-          view_path = match[1]
+          view_path = extract_path_after(file_path, 'app/views/')
+          return unless view_path
 
           { type: :view, view_path: view_path }
         end
 
-        def detect_component_context(node)
+        def detect_component_context(node, file_path)
+          # Template files (e.g. erb) have no class/def AST nodes, so derive the
+          # scope from the file path like detect_view_context does.
+          return detect_component_template_context(file_path) unless file_path.end_with?('.rb')
+
           # Find the class definition
           class_node = node.each_ancestor(:class).first
           return unless class_node
@@ -138,6 +140,22 @@ module RuboCop
           return unless method_node
 
           { type: :component, class_node: class_node, method_node: method_node }
+        end
+
+        def detect_component_template_context(file_path)
+          # Extract component path like "book_component" from
+          # "app/components/book_component.html.erb"
+          component_path = extract_path_after(file_path, 'app/components/')
+          return unless component_path
+
+          { type: :component_template, component_path: component_path }
+        end
+
+        # Extract the extension-less path that follows +prefix+, e.g.
+        # ("app/views/books/index.html.erb", "app/views/") => "books/index"
+        def extract_path_after(file_path, prefix)
+          match = file_path.match(%r{#{Regexp.escape(prefix)}(.+?)(?:\.[^/]+)*$})
+          match && match[1]
         end
 
         def get_scoped_key(key_node, context)
@@ -156,6 +174,8 @@ module RuboCop
           when :component
             path = component_path(context[:class_node])
             "#{path}.#{key}"
+          when :component_template
+            "#{context[:component_path].tr('/', '.')}.#{key}"
           end
         end
 

--- a/spec/rubocop/cop/sgcop/i18n_lazy_lookup_spec.rb
+++ b/spec/rubocop/cop/sgcop/i18n_lazy_lookup_spec.rb
@@ -120,6 +120,36 @@ describe RuboCop::Cop::Sgcop::I18nLazyLookup do
       end
     end
 
+    context 'コンポーネントのerbテンプレート' do
+      it 'lazy lookupを使用している場合は警告される' do
+        expect_offense(<<~RUBY, 'app/components/book_component.html.erb')
+          t('.title')
+            ^^^^^^^^ Use explicit key for better maintainability.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          t('book_component.title')
+        RUBY
+      end
+
+      it '明示的なキーを使用している場合は警告されない' do
+        expect_no_offenses(<<~RUBY, 'app/components/book_component.html.erb')
+          t('book_component.title')
+        RUBY
+      end
+
+      it 'ネストしたコンポーネントのerbでも正しく動作する' do
+        expect_offense(<<~RUBY, 'app/components/admin/user_card_component.html.erb')
+          t('.header')
+            ^^^^^^^^^ Use explicit key for better maintainability.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          t('admin.user_card_component.header')
+        RUBY
+      end
+    end
+
     context 'translateメソッド' do
       it 'translateでも警告される' do
         expect_offense(<<~RUBY, 'app/controllers/books_controller.rb')


### PR DESCRIPTION
## 概要

`Sgcop/I18nLazyLookup` がコンポーネントの erb テンプレート（例: `.html.erb`）でも正しく動作するように対応しました。

## 変更内容

- テンプレートファイルには class/def の AST ノードが存在しないため、ビューテンプレートと同様にファイルパスから i18n スコープを導出するよう修正
- `extract_path_after` ヘルパーを追加し、ビュー・コンポーネントテンプレート両方でパス抽出ロジックを共通化
- `Include` の glob を `app/components/**/*.rb` から `app/components/**/*` に拡張し、`.rb` 以外のコンポーネントファイルもチェック対象に追加
- コンポーネント erb テンプレートに対するテストケースを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)