### PR TITLE
[review] feat: 指定子と区切り記号のみのstrftimeフォーマットをデフォルト許容する

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ sgcopが提供するカスタムCopの一覧です。
 | [`Sgcop/I18nLocalizeFormatString`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/i18n_localize_format_string.rb) | I18n.lのformatオプションで文字列使用を制限し、シンボル使用を推奨 | ✅ |
 | [`Sgcop/MethodArgumentNameDuplication`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/method_argument_name_duplication.rb) | メソッド名と完全一致する引数名を禁止（紛らわしさを防止） | ✅ |
 | [`Sgcop/RestrictedViewHelpers`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/restricted_view_helpers.rb) | 特定のビューヘルパーメソッドの使用を制限（設定でカスタマイズ可能） | ✅ |
-| [`Sgcop/StrftimeRestriction`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/strftime_restriction.rb) | strftimeメソッドの使用を制限し、I18n.lの使用を推奨 | ✅ |
+| [`Sgcop/StrftimeRestriction`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/strftime_restriction.rb) | リテラル単語を含むstrftimeの使用を制限し、I18n.lの使用を推奨（指定子と区切り記号 `- / : . 空白` のみのフォーマットは許容） | ✅ |
 
 ## しつけ方
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -265,14 +265,13 @@ Sgcop/RestrictedViewHelpers:
   RestrictedMethods: []
 
 Sgcop/StrftimeRestriction:
-  Description: "strftimeではなくI18n.lを使用してローカライズしてください"
+  Description: "リテラル単語を含むstrftimeではなくI18n.lを使用してローカライズしてください。指定子と区切り記号(- / : . 空白)のみの場合は許容します"
   Enabled: true
   Include:
     - "app/**/*"
-  AllowedPatterns:
-    - "%a"  # 曜日の省略名 (Sun, Mon, etc.)
-    - "%A"  # 曜日の完全名 (Sunday, Monday, etc.)
-    - "%w"  # 曜日の数字 (0=Sunday, 1=Monday, etc.)
+  # 指定子(%Y 等)と区切り記号(- / : . 空白)のみで構成されるフォーマットはデフォルトで許容されます。
+  # ここに完全一致の文字列を追加すると、リテラルを含むフォーマットも例外的に許容できます。
+  AllowedPatterns: []
   Reference:
     - https://guides.rubyonrails.org/i18n.html#adding-date-time-formats
 

--- a/lib/rubocop/cop/sgcop/strftime_restriction.rb
+++ b/lib/rubocop/cop/sgcop/strftime_restriction.rb
@@ -6,6 +6,21 @@ module RuboCop
       class StrftimeRestriction < Base
         MSG = 'strftimeではなくI18n.lを使用してローカライズしてください。'
 
+        # 指定子(%Y, %-d, %3N, %EY, %::z, %% 等)と区切り記号(- / : . 空白)のみで
+        # 構成されるフォーマットは許容する。年・月・日などのリテラル単語が混ざる場合は
+        # ロケール対応のため I18n.l を使うべきなので警告する。
+        ALLOWED_FORMAT_REGEXP = %r{
+          \A
+          (?:
+            %%
+            |
+            %[-_0^#+]*(?::{1,3})?\d*[EO]?[A-Za-z]
+            |
+            [-/:.\s]
+          )*
+          \z
+        }x.freeze
+
         def on_send(node)
           return unless node.method_name == :strftime
           return if allowed_pattern?(node)
@@ -22,7 +37,7 @@ module RuboCop
           return false unless first_argument.str_type?
 
           pattern = first_argument.value
-          allowed_patterns.include?(pattern)
+          ALLOWED_FORMAT_REGEXP.match?(pattern) || allowed_patterns.include?(pattern)
         end
 
         def allowed_patterns

--- a/spec/rubocop/cop/sgcop/strftime_restriction_spec.rb
+++ b/spec/rubocop/cop/sgcop/strftime_restriction_spec.rb
@@ -5,122 +5,51 @@ describe RuboCop::Cop::Sgcop::StrftimeRestriction do
   let(:config) { RuboCop::Config.new(cop_config) }
   let(:cop_config) { { 'Sgcop/StrftimeRestriction' => {} } }
 
-  it 'Date.todayでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Date.today.strftime('%Y-%m-%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'Time.nowでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Time.now.strftime('%H:%M:%S')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'DateTime.nowでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      DateTime.now.strftime('%Y年%m月%d日')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'Time.currentでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Time.current.strftime('%Y/%m/%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'Time.zoneでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Time.zone.now.strftime('%Y-%m-%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it '変数に格納された日付オブジェクトでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      def format_date
-        date = Date.today
-        date.strftime('%Y-%m-%d')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-      end
-    RUBY
-  end
-
-  it 'インスタンス変数の日付オブジェクトでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      def format_date
-        @created_at.strftime('%Y-%m-%d')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-      end
-    RUBY
-  end
-
-  it 'to_dateの結果でstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      '2024-01-01'.to_date.strftime('%B %d, %Y')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'ActiveSupport::TimeWithZoneでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Time.zone.parse('2024-01-01').strftime('%Y-%m-%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it '1.day.agoでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      1.day.ago.strftime('%Y-%m-%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'beginning_of_monthでstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      Date.today.beginning_of_month.strftime('%Y-%m')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it 'I18n.lが使用されている場合は警告されない' do
-    expect_no_offenses(<<~RUBY)
-      I18n.l(Date.today, format: :long)
-    RUBY
-  end
-
-  it 'I18n.localizeが使用されている場合は警告されない' do
-    expect_no_offenses(<<~RUBY)
-      I18n.localize(Time.now, format: :short)
-    RUBY
-  end
-
-  it '日付オブジェクト以外でもstrftimeが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      some_object.strftime('%Y-%m-%d')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-    RUBY
-  end
-
-  it '複数のstrftimeが使用された場合は全て警告される' do
-    expect_offense(<<~RUBY)
-      def format_dates
+  context '指定子と区切り記号のみで構成される場合は許容される' do
+    it 'ハイフン区切り（%Y-%m-%d）は警告されない' do
+      expect_no_offenses(<<~RUBY)
         Date.today.strftime('%Y-%m-%d')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it 'スラッシュ区切り（%Y/%m/%d）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Time.current.strftime('%Y/%m/%d')
+      RUBY
+    end
+
+    it 'コロン区切り（%H:%M:%S）は警告されない' do
+      expect_no_offenses(<<~RUBY)
         Time.now.strftime('%H:%M:%S')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-        @updated_at.strftime('%Y年%m月%d日')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
-      end
-    RUBY
+      RUBY
+    end
+
+    it 'ドット区切り（%Y.%m.%d）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Date.today.strftime('%Y.%m.%d')
+      RUBY
+    end
+
+    it '区切りなしの指定子連続（%Y%m%d）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Date.today.strftime('%Y%m%d')
+      RUBY
+    end
+
+    it '空白区切り（%H %M）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Time.now.strftime('%H %M')
+      RUBY
+    end
+
+    it '%%エスケープを含む（%% %Y）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Time.now.strftime('%% %Y')
+      RUBY
+    end
   end
 
-  context '許可されたパターンの場合' do
-    let(:cop_config) { { 'Sgcop/StrftimeRestriction' => { 'AllowedPatterns' => ['%a', '%A', '%w'] } } }
+  context '曜日関連の指定子単体は設定なしでも許容される' do
     it '%aパターンは警告されない' do
       expect_no_offenses(<<~RUBY)
         Date.today.strftime('%a')
@@ -138,28 +67,138 @@ describe RuboCop::Cop::Sgcop::StrftimeRestriction do
         DateTime.now.strftime('%w')
       RUBY
     end
+  end
 
-    it '許可されていないパターンは警告される' do
-      expect_offense(<<~RUBY)
-        Date.today.strftime('%Y-%m-%d')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+  context 'フラグ・幅・修飾子付きの指定子は許容される' do
+    it 'フラグ付き（%-d）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Date.today.strftime('%-d')
       RUBY
     end
 
-    it '引数が動的な場合は警告される' do
-      expect_offense(<<~RUBY)
-        format = '%a'
-        Date.today.strftime(format)
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+    it '幅付き（%3N）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Time.now.strftime('%3N')
+      RUBY
+    end
+
+    it 'コロン形式のタイムゾーン（%::z）は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Time.now.strftime('%::z')
       RUBY
     end
   end
 
-  context 'AllowedPatternsが設定されていない場合' do
-    it '%aパターンも警告される' do
+  context 'リテラル単語が混ざる場合は警告される' do
+    it '日本語リテラル（%Y年%m月%d日）は警告される' do
       expect_offense(<<~RUBY)
-        Date.today.strftime('%a')
-        ^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+        DateTime.now.strftime('%Y年%m月%d日')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it '日本語1文字混在（%Y年）は警告される' do
+      expect_offense(<<~RUBY)
+        Date.today.strftime('%Y年')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it 'カンマと英字リテラル（%B %d, %Y）は警告される' do
+      expect_offense(<<~RUBY)
+        '2024-01-01'.to_date.strftime('%B %d, %Y')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it '英単語リテラル（Today is %A）は警告される' do
+      expect_offense(<<~RUBY)
+        Time.now.strftime('Today is %A')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+  end
+
+  context 'レシーバの種類を問わずリテラル混在は警告される' do
+    it 'インスタンス変数の日付オブジェクト' do
+      expect_offense(<<~RUBY)
+        @created_at.strftime('%Y年%m月%d日')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it 'メソッドチェーンの結果' do
+      expect_offense(<<~RUBY)
+        Date.today.beginning_of_month.strftime('%Y年%m月')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it '日付オブジェクト以外でも警告される' do
+      expect_offense(<<~RUBY)
+        some_object.strftime('%Y年%m月%d日')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+  end
+
+  context '動的・引数なしの場合は警告される' do
+    it '引数が動的（変数）な場合は警告される' do
+      expect_offense(<<~RUBY)
+        format = '%Y年%m月%d日'
+        Date.today.strftime(format)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+
+    it '引数なしの場合は警告される' do
+      expect_offense(<<~RUBY)
+        Date.today.strftime
+        ^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+      RUBY
+    end
+  end
+
+  context 'リテラル混在と指定子のみが混在する場合' do
+    it 'リテラル入りのものだけ警告される' do
+      expect_offense(<<~RUBY)
+        def format_dates
+          Date.today.strftime('%Y-%m-%d')
+          Time.now.strftime('%H:%M:%S')
+          @updated_at.strftime('%Y年%m月%d日')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
+        end
+      RUBY
+    end
+  end
+
+  context 'I18n.lが使用されている場合は警告されない' do
+    it 'I18n.l' do
+      expect_no_offenses(<<~RUBY)
+        I18n.l(Date.today, format: :long)
+      RUBY
+    end
+
+    it 'I18n.localize' do
+      expect_no_offenses(<<~RUBY)
+        I18n.localize(Time.now, format: :short)
+      RUBY
+    end
+  end
+
+  context 'AllowedPatternsに完全一致を指定した場合（後方互換）' do
+    let(:cop_config) { { 'Sgcop/StrftimeRestriction' => { 'AllowedPatterns' => ['%Y年%m月%d日'] } } }
+
+    it '完全一致するリテラル入りフォーマットは警告されない' do
+      expect_no_offenses(<<~RUBY)
+        Date.today.strftime('%Y年%m月%d日')
+      RUBY
+    end
+
+    it '一致しない別のリテラル入りフォーマットは警告される' do
+      expect_offense(<<~RUBY)
+        Date.today.strftime('%Y年%m月')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ strftimeではなくI18n.lを使用してローカライズしてください。
       RUBY
     end
   end


### PR DESCRIPTION
## 概要

`Sgcop/StrftimeRestriction` を「strftime指定子と区切り記号(`- / : . 空白`)のみで構成されるフォーマットはデフォルト許容、リテラル単語が混ざる場合のみ警告」に変更しました。

`%Y-%m-%d` や `%H:%M:%S` のような数値中心のフォーマットはロケールで表現が変わらず I18n.l を使うべきでないため許容します。一方 `%Y年%m月%d日` のように年月日などのリテラル単語が混ざる場合はロケール対応のため I18n.l を推奨して警告します。

## 変更点

- `ALLOWED_FORMAT_REGEXP` を追加し、指定子(`%Y` `%-d` `%3N` `%EY` `%::z` `%%` 等)＋区切り記号のみのフォーマットを許容
- デフォルトの `AllowedPatterns`(`%a %A %w`)は新ロジックで自動許容されるため空配列化。完全一致の `AllowedPatterns` は後方互換のため fallback として維持
- `config/default.yml` の Description / コメント、`README.md` の Cop 一覧を更新
- spec を新仕様に合わせて全面書き換え