### PR TITLE
[review] chore: drop Ruby 3.1/3.2 support and test against 4.0

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -2,7 +2,7 @@ name: Ruby
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.3'
+
   spec.add_dependency 'rubocop', '~> 1.87.0'
   spec.add_dependency 'rubocop-capybara', '~> 2.23.0'
   spec.add_dependency 'rubocop-factory_bot', '~> 2.28.0'


### PR DESCRIPTION
## 概要

EOL に近づいた Ruby 3.1/3.2 のサポートを終了し、安定版 4.0 を CI 検証に追加。

## 変更内容

- CI マトリクスを `3.1, 3.2, 3.3, 3.4` → `3.3, 3.4, 4.0` に変更
- gemspec に `required_ruby_version = '>= 3.3'` を追加してサポート下限を明示
- （差分に含まれる）ワークフローの push トリガを `master` → `main` に修正