### PR TITLE
[review] chore: bump rubocop to 1.88

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -634,6 +634,10 @@ Style/SelectByRange: # new in 1.85
 # https://docs.rubocop.org/rubocop/latest/cops_style.html#styletallymethod
 Style/TallyMethod: # new in 1.85
   Enabled: true
+# https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemutableconstant
+Style/MutableConstant:
+  Enabled: true
+  Recursive: true
 
 # ============================================================
 # Lint
@@ -704,7 +708,7 @@ Layout/MultilineHashKeyLineBreaks:
 # https://docs.rubocop.org/rubocop/latest/cops_bundler.html#bundlergemcomment
 Bundler/GemComment:
   Enabled: true
-  IgnoredGems:
+  AllowedGems:
     - rails
   OnlyFor:
     - version_specifiers

--- a/sgcop.gemspec
+++ b/sgcop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.87.0'
+  spec.add_dependency 'rubocop', '~> 1.88.0'
   spec.add_dependency 'rubocop-capybara', '~> 2.23.0'
   spec.add_dependency 'rubocop-factory_bot', '~> 2.28.0'
   spec.add_dependency 'rubocop-performance', '~> 1.26.0'


### PR DESCRIPTION
## 概要

- rubocop の依存バージョンを `~> 1.87.0` から `~> 1.88.0` に更新
- 1.88 向けに `ruby/rubocop.yml` を調整
  - `Style/MutableConstant` の`Recursive`オプションを有効化（`Recursive: true`）
  - `Bundler/GemComment` の `IgnoredGems` を `AllowedGems` にリネーム