### PR TITLE
feat: add weekly gem version check workflow

### DIFF
--- a/.github/scripts/check_gem_versions.rb
+++ b/.github/scripts/check_gem_versions.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+gemspec_path = File.expand_path('../../sgcop.gemspec', __dir__)
+pr_body_path = File.expand_path('../../pr_body.md', __dir__)
+content = File.read(gemspec_path)
+
+updates = []
+
+content.gsub!(/spec\.add_dependency '(?<name>[^']+)', '~> (?<version>\d+\.\d+\.\d+)'/) do
+  m = Regexp.last_match
+  name = m[:name]
+  current = Gem::Version.new(m[:version])
+
+  uri = URI("https://rubygems.org/api/v1/gems/#{name}.json")
+  data = JSON.parse(Net::HTTP.get(uri))
+  latest = Gem::Version.new(data['version'])
+  major, minor, = latest.segments
+  new_version = "#{major}.#{minor}.0"
+
+  # major/minor が上がったときだけ更新（patch だけの差は ~> 制約内なので追従不要）
+  if (latest.segments.first(2) <=> current.segments.first(2)).positive?
+    puts "#{name}: #{current} -> #{new_version} (latest: #{latest})"
+    changelog_url = data['changelog_uri'] ||
+                    data.dig('metadata', 'changelog_uri') ||
+                    data['source_code_uri'] ||
+                    data['homepage_uri']
+    updates << { name: name, old: current.to_s, new: new_version, changelog_url: changelog_url }
+    "spec.add_dependency '#{name}', '~> #{new_version}'"
+  else
+    puts "#{name}: #{current} (up to date, latest: #{latest})"
+    m[0]
+  end
+end
+
+if updates.empty?
+  puts "\nAll gems are up to date."
+else
+  File.write(gemspec_path, content)
+  puts "\nsgcop.gemspec updated."
+
+  rows = updates.map do |u|
+    changelog = u[:changelog_url] ? "[CHANGELOG](#{u[:changelog_url]})" : '-'
+    "| #{u[:name]} | `~> #{u[:old]}` → `~> #{u[:new]}` | #{changelog} |"
+  end
+  File.write(pr_body_path, <<~BODY)
+    RubyGems の最新バージョンに合わせて gemspec の制約を更新しました。
+
+    ## 更新された依存
+
+    | gem | 変更 | CHANGELOG |
+    |-----|------|-----------|
+    #{rows.join("\n")}
+  BODY
+  puts 'pr_body.md written.'
+end

--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -1,0 +1,47 @@
+name: Gem Version Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # 毎週月曜 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Check and update gem versions
+        run: ruby .github/scripts/check_gem_versions.rb
+
+      - name: Create PR if updated
+        run: |
+          # スクリプトが pr_body.md を生成した場合のみ更新あり（判定の単一ソース）
+          if [ ! -f pr_body.md ]; then
+            echo "No updates found."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          branch="gem-version-update"
+          git checkout -B "$branch"
+          git add sgcop.gemspec
+          git commit -m "chore: update gem version constraints"
+          git push --force origin "$branch"
+          # 既存の未マージPRがあれば作り直さない（常に1本に保つ）
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --title "chore: update gem version constraints" \
+              --body-file pr_body.md \
+              --base main \
+              --head "$branch"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -35,13 +35,17 @@ jobs:
           git add sgcop.gemspec
           git commit -m "chore: update gem version constraints"
           git push --force origin "$branch"
-          # 既存の未マージPRがあれば作り直さない（常に1本に保つ）
-          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+          # 常に1本のPRに保つ。既存の未マージPRがあれば本文を更新し、無ければ新規作成する
+          # （force push で diff だけ更新され本文が古いまま乖離するのを防ぐ）
+          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[].number')"
+          if [ -z "$pr_number" ]; then
             gh pr create \
               --title "chore: update gem version constraints" \
               --body-file pr_body.md \
               --base main \
               --head "$branch"
+          else
+            gh pr edit "$pr_number" --body-file pr_body.md
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
RubyGems API でマイナー以上のバージョンアップを週次検知し、gemspec を自動更新して PR を作成するワークフローを追加。

- `.github/scripts/check_gem_versions.rb`: `Gem::Version` で比較し、更新があれば gemspec を書き換え、CHANGELOGリンク付きの PR 本文（`pr_body.md`）を生成
- `.github/workflows/gem-version-check.yml`: 毎週月曜 09:00 UTC に実行。`pr_body.md` の存在を単一の更新判定ソースとし、固定ブランチ `gem-version-update` へ force push して PR を作成（既存の未マージ PR があれば作り直さない）