### PR TITLE
chore: update actions/checkout to v7 and ruby to 4.0

### DIFF
--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -12,11 +12,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '4.0'
 
       - name: Check and update gem versions
         run: ruby .github/scripts/check_gem_versions.rb


### PR DESCRIPTION
- `actions/checkout` を v4 → v7（最新）に更新
- `gem-version-check` ワークフローで使用する Ruby バージョンを 3.3 → 4.0 に更新