### PR TITLE
[review] feat: add Sgcop/FormLabelFirstArgument cop

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ sgcopが提供するカスタムCopの一覧です。
 | [`Sgcop/NoAcceptsNestedAttributesFor`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/no_accepts_nested_attributes_for.rb) | accepts_nested_attributes_forの使用を制限 | ❌ |
 | [`Sgcop/NoModelMethodsInMigration`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/no_model_methods_in_migration.rb) | マイグレーションでモデルのメソッド呼び出しを検出 | ✅ |
 | [`Sgcop/ErrorMessageFormat`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/error_message_format.rb) | エラーメッセージはシンボルを使用することを強制 | ❌ |
+| [`Sgcop/FormLabelFirstArgument`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/form_label_first_argument.rb) | f.labelの第一引数にはテキストではなく属性名（Symbol）を指定することを強制 | ✅ |
 | [`Sgcop/OnLoadArguments`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/on_load_arguments.rb) | on_loadブロックの引数使用をチェック | ✅ |
 | [`Sgcop/PreferAbsolutePathPartial`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/prefer_absolute_path_partial.rb) | パーシャルファイルのrenderは絶対パスで指定（autocorrect対応） | ✅ |
 | [`Sgcop/RequestRemoteIp`](https://github.com/SonicGarden/sgcop/blob/main/lib/rubocop/cop/sgcop/request_remote_ip.rb) | request.remote_ipの適切な使用を確認 | ✅ |

--- a/config/default.yml
+++ b/config/default.yml
@@ -15,6 +15,10 @@ Sgcop/SimpleFormAssociation:
 Sgcop/FormLabelFirstArgument:
   Description: "f.labelの第一引数にテキストを渡すと属性名としてhumanizeされてしまうよ。第一引数は属性名(Symbol)にして、テキストは第二引数に渡そう"
   Enabled: true
+  Include:
+    - "app/views/**/*"
+    - "app/helpers/**/*.rb"
+    - "app/components/**/*"
   Reference:
     - https://github.com/SonicGarden/copy-tuner-ruby-client/pull/131
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,6 +12,12 @@ Sgcop/SimpleFormAssociation:
   Description: "simple_formのassociationメソッドではcollectionを明示しよう"
   Enabled: true
 
+Sgcop/FormLabelFirstArgument:
+  Description: "f.labelの第一引数にテキストを渡すと属性名としてhumanizeされてしまうよ。第一引数は属性名(Symbol)にして、テキストは第二引数に渡そう"
+  Enabled: true
+  Reference:
+    - https://github.com/SonicGarden/copy-tuner-ruby-client/pull/131
+
 Sgcop/RequestRemoteIp:
   Description: "クライアントのIPを取得するならrequest.remote_ipの必要があるよ"
   Enabled: true

--- a/lib/rubocop/cop/sgcop/form_label_first_argument.rb
+++ b/lib/rubocop/cop/sgcop/form_label_first_argument.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Sgcop
+      class FormLabelFirstArgument < Base
+        MSG = 'f.label の第一引数には属性名(Symbol)を渡してください。' \
+              'ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。'
+
+        FORM_BUILDER_NAMES = %i[f ff fff form].freeze
+
+        # receiver あり ＆ メソッド名 label ＆ 第一引数を捕捉。
+        # 引数ゼロはマッチしない(第一引数の捕捉が必須)。
+        def_node_matcher :form_label_call?, <<~PATTERN
+          (send $_ :label $_ ...)
+        PATTERN
+
+        def on_send(node)
+          form_label_call?(node) do |receiver, first_arg|
+            return unless form_builder_receiver?(receiver)
+            return unless text_like?(first_arg)
+
+            add_offense(first_arg)
+          end
+        end
+
+        private
+
+        # `f` / `form` 等のブロック変数(lvar)か、レシーバ無しメソッド呼び出し(send nil? :f)に限定
+        def form_builder_receiver?(receiver)
+          return false if receiver.nil?
+
+          name =
+            if receiver.lvar_type?
+              receiver.children.first
+            elsif receiver.send_type? && receiver.receiver.nil?
+              receiver.method_name
+            end
+
+          FORM_BUILDER_NAMES.include?(name)
+        end
+
+        # 「明らかにテキスト」のみ警告対象にする。
+        # 変数・メソッド戻り値(lvar/send/ivar 等)は Symbol を返す可能性があるため見逃す。
+        def text_like?(arg)
+          arg.str_type? || arg.dstr_type? || translation_call?(arg)
+        end
+
+        def translation_call?(arg)
+          return false unless arg.send_type?
+
+          %i[t translate].include?(arg.method_name) &&
+            (arg.receiver.nil? || i18n_receiver?(arg.receiver))
+        end
+
+        def i18n_receiver?(receiver)
+          receiver.const_type? && receiver.short_name == :I18n
+        end
+      end
+    end
+  end
+end

--- a/lib/sgcop.rb
+++ b/lib/sgcop.rb
@@ -7,6 +7,7 @@ Sgcop::Inject.defaults!
 require 'rubocop/cop/sgcop/simple_format'
 require 'rubocop/cop/sgcop/request_remote_ip'
 require 'rubocop/cop/sgcop/simple_form_association'
+require 'rubocop/cop/sgcop/form_label_first_argument'
 require 'rubocop/cop/sgcop/unscoped'
 require 'rubocop/cop/sgcop/ujs_options'
 require 'rubocop/cop/sgcop/active_job_queue_adapter'

--- a/spec/rubocop/cop/sgcop/form_label_first_argument_spec.rb
+++ b/spec/rubocop/cop/sgcop/form_label_first_argument_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe RuboCop::Cop::Sgcop::FormLabelFirstArgument do
+  subject(:cop) { RuboCop::Cop::Sgcop::FormLabelFirstArgument.new }
+
+  context '第一引数がテキストの場合は警告' do
+    it '文字列リテラル' do
+      expect_offense(<<~RUBY)
+        f.label "キーワード"
+                ^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+
+    it 't() ヘルパー' do
+      expect_offense(<<~RUBY)
+        f.label t('activerecord.attributes.field.keywords')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+
+    it 'I18n.t() ヘルパー' do
+      expect_offense(<<~RUBY)
+        f.label I18n.t('activerecord.attributes.field.keywords')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+
+    it '式展開込みの文字列' do
+      expect_offense(<<~'RUBY')
+        f.label "#{prefix}名"
+                ^^^^^^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+
+    it 'form というレシーバ名でも警告' do
+      expect_offense(<<~RUBY)
+        form.label "キーワード"
+                   ^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+
+    it 'ff というレシーバ名でも警告' do
+      expect_offense(<<~RUBY)
+        ff.label t('foo.bar')
+                 ^^^^^^^^^^^^ Sgcop/FormLabelFirstArgument: f.label の第一引数には属性名(Symbol)を渡してください。ラベルテキストは第二引数に渡します(例: `f.label :name, t("...")`)。
+      RUBY
+    end
+  end
+
+  context '第一引数が属性名(Symbol)など正当な場合は警告しない' do
+    it 'Symbol + 第二引数にテキスト(正しい用法)' do
+      expect_no_offenses(<<~RUBY)
+        f.label :keywords_cont, t('activerecord.attributes.field.keywords')
+      RUBY
+    end
+
+    it 'Symbol のみ' do
+      expect_no_offenses(<<~RUBY)
+        f.label :name
+      RUBY
+    end
+
+    it '引数ゼロ' do
+      expect_no_offenses(<<~RUBY)
+        f.label
+      RUBY
+    end
+
+    it 'ローカル変数(Symbol を保持している可能性)' do
+      expect_no_offenses(<<~RUBY)
+        @columns.each do |column|
+          f.label column
+        end
+      RUBY
+    end
+
+    it 'メソッド戻り値(Symbol を返す可能性)' do
+      expect_no_offenses(<<~RUBY)
+        f.label attr_name
+      RUBY
+    end
+  end
+
+  context 'f系でないレシーバやヘルパーは対象外' do
+    it 'label_tag (レシーバ無しヘルパー)' do
+      expect_no_offenses(<<~RUBY)
+        label_tag "Name"
+      RUBY
+    end
+
+    it 'f系でないレシーバの .label' do
+      expect_no_offenses(<<~RUBY)
+        chart.label "売上"
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## 変更内容

- `Sgcop/FormLabelFirstArgument` copを新規追加
- `f.label` の第一引数に文字列リテラル・`t()`・`I18n.t()` を渡すと属性名として `humanize` されてしまう問題を検出する
- レシーバ名を `f` / `ff` / `fff` / `form` に限定し、変数・メソッド戻り値は誤検知を避けるため見逃す

## 参考

https://github.com/SonicGarden/copy-tuner-ruby-client/pull/131