### PR TITLE
test: NoLetOverride 違反を解消し spec を :config shared_context に統一する

### DIFF
--- a/spec/rubocop/cop/sgcop/active_storage_service_configuration_spec.rb
+++ b/spec/rubocop/cop/sgcop/active_storage_service_configuration_spec.rb
@@ -3,9 +3,6 @@ require 'spec_helper'
 describe RuboCop::Cop::Sgcop::ActiveStorageServiceConfiguration do
   subject(:cop) { described_class.new }
 
-  let(:storage_yml) { "test:\n  service: Disk\nlocal:\n  service: Disk\namazon:\n  service: S3\n" }
-  let(:storage_yml_exists) { true }
-
   before do
     allow(Dir).to receive(:pwd).and_return('/fakepath')
     allow(File).to receive(:exist?).and_call_original
@@ -15,6 +12,9 @@ describe RuboCop::Cop::Sgcop::ActiveStorageServiceConfiguration do
   end
 
   context 'when storage.yml has a cloud service' do
+    let(:storage_yml) { "test:\n  service: Disk\nlocal:\n  service: Disk\namazon:\n  service: S3\n" }
+    let(:storage_yml_exists) { true }
+
     it 'registers an offense for service = :local' do
       expect_offense(<<~RUBY, 'config/environments/production.rb')
         Rails.application.configure do
@@ -44,6 +44,7 @@ describe RuboCop::Cop::Sgcop::ActiveStorageServiceConfiguration do
 
   context 'when storage.yml only has Disk services' do
     let(:storage_yml) { "test:\n  service: Disk\nlocal:\n  service: Disk\n" }
+    let(:storage_yml_exists) { true }
 
     it 'does not register an offense even when the service setting is missing' do
       expect_no_offenses(<<~RUBY, 'config/environments/production.rb')
@@ -55,6 +56,7 @@ describe RuboCop::Cop::Sgcop::ActiveStorageServiceConfiguration do
   end
 
   context 'when storage.yml does not exist' do
+    let(:storage_yml) { "test:\n  service: Disk\nlocal:\n  service: Disk\namazon:\n  service: S3\n" }
     let(:storage_yml_exists) { false }
 
     it 'does not register an offense' do
@@ -67,6 +69,9 @@ describe RuboCop::Cop::Sgcop::ActiveStorageServiceConfiguration do
   end
 
   context 'when the file is not production.rb' do
+    let(:storage_yml) { "test:\n  service: Disk\nlocal:\n  service: Disk\namazon:\n  service: S3\n" }
+    let(:storage_yml_exists) { true }
+
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY, 'config/environments/development.rb')
         Rails.application.configure do

--- a/spec/rubocop/cop/sgcop/capybara/spec_stability_check_spec.rb
+++ b/spec/rubocop/cop/sgcop/capybara/spec_stability_check_spec.rb
@@ -2,14 +2,12 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck do
-  subject(:cop) { RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck.new }
-
+describe RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck, :config do
   context 'with default configuration' do
     it 'registers an offense when assert_enqueued_emails block lacks wait matcher' do
       expect_offense(<<~RUBY)
         assert_enqueued_emails 1 do
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Capybara/SpecStabilityCheck: ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
+        ^^^^^^^^^^^^^^^^^^^^^^^^ ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
           within('tbody tr', text: '第2希望') do
             click_button '確定する'
           end
@@ -31,7 +29,7 @@ describe RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck do
     it 'registers an offense for form submission without wait matcher' do
       expect_offense(<<~RUBY)
         assert_enqueued_emails 1 do
-        ^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/Capybara/SpecStabilityCheck: ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
+        ^^^^^^^^^^^^^^^^^^^^^^^^ ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
           fill_in 'Email', with: 'user@example.com'
           click_button '送信'
         end
@@ -51,7 +49,7 @@ describe RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck do
     it 'registers an offense for cancellation action without wait matcher' do
       expect_offense(<<~RUBY)
         assert_no_emails do
-        ^^^^^^^^^^^^^^^^ Sgcop/Capybara/SpecStabilityCheck: ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
+        ^^^^^^^^^^^^^^^^ ページの変化を伴う非同期処理後には、適切な待機処理（例: expect(page).to have_content('更新しました。')）を追加してテストを安定させましょう
           click_button 'キャンセル'
         end
       RUBY
@@ -86,14 +84,11 @@ describe RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck do
   end
 
   context 'with custom configuration' do
-    subject(:cop) do
-      config = RuboCop::Config.new(
-        'Sgcop/Capybara/SpecStabilityCheck' => {
-          'WatchedMethods' => %w[assert_enqueued_jobs],
-          'WaitMatcherPatterns' => ['^have_text$', '^custom_matcher$'],
-        }
-      )
-      RuboCop::Cop::Sgcop::Capybara::SpecStabilityCheck.new(config)
+    let(:cop_config) do
+      {
+        'WatchedMethods' => %w[assert_enqueued_jobs],
+        'WaitMatcherPatterns' => ['^have_text$', '^custom_matcher$'],
+      }
     end
 
     it 'works with custom watched methods for background jobs' do

--- a/spec/rubocop/cop/sgcop/enumerize_predicates_option_spec.rb
+++ b/spec/rubocop/cop/sgcop/enumerize_predicates_option_spec.rb
@@ -1,13 +1,9 @@
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::EnumerizePredicatesOption do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new(cop_config) }
-  let(:cop_config) { { 'Sgcop/EnumerizePredicatesOption' => { 'AllowWithPrefix' => allow_with_prefix } } }
-  let(:allow_with_prefix) { false }
-
+describe RuboCop::Cop::Sgcop::EnumerizePredicatesOption, :config do
   context 'when AllowWithPrefix is false' do
+    let(:cop_config) { { 'AllowWithPrefix' => false } }
+
     it 'registers an offense when using predicates: true' do
       expect_offense(<<~RUBY)
         enumerize :status, in: %w[active inactive], predicates: true
@@ -65,7 +61,7 @@ describe RuboCop::Cop::Sgcop::EnumerizePredicatesOption do
   end
 
   context 'when AllowWithPrefix is true' do
-    let(:allow_with_prefix) { true }
+    let(:cop_config) { { 'AllowWithPrefix' => true } }
 
     it 'registers an offense with message suggesting prefix when using predicates: true' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/sgcop/no_model_methods_in_migration_spec.rb
+++ b/spec/rubocop/cop/sgcop/no_model_methods_in_migration_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::NoModelMethodsInMigration do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new(cop_config) }
-  let(:cop_config) { { 'Sgcop/NoModelMethodsInMigration' => { 'AllowedConstants' => allowed_constants } } }
-  let(:allowed_constants) { [] }
-
+describe RuboCop::Cop::Sgcop::NoModelMethodsInMigration, :config do
   it 'registers an offense for a model method call' do
     expect_offense(<<~RUBY)
       User.delete_all
@@ -93,7 +87,7 @@ describe RuboCop::Cop::Sgcop::NoModelMethodsInMigration do
   end
 
   context 'when the constant is allowed via AllowedConstants' do
-    let(:allowed_constants) { ['User'] }
+    let(:cop_config) { { 'AllowedConstants' => ['User'] } }
 
     it 'does not register an offense' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sgcop/restricted_view_helpers_spec.rb
+++ b/spec/rubocop/cop/sgcop/restricted_view_helpers_spec.rb
@@ -1,74 +1,66 @@
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::RestrictedViewHelpers do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) do
-    RuboCop::Config.new(
-      'Sgcop/RestrictedViewHelpers' => {
+describe RuboCop::Cop::Sgcop::RestrictedViewHelpers, :config do
+  context '禁止メソッドが設定されている場合' do
+    let(:cop_config) do
+      {
         'RestrictedMethods' => {
           'simple_format' => 'cssで改行反映されるようにしてください。',
           'raw' => 'sanitizeメソッドを使用してください。',
         },
       }
-    )
-  end
+    end
 
-  it 'simple_formatが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      def some_method
-        simple_format(text)
-        ^^^^^^^^^^^^^^^^^^^ cssで改行反映されるようにしてください。
-      end
-    RUBY
-  end
+    it 'simple_formatが使用された場合は警告される' do
+      expect_offense(<<~RUBY)
+        def some_method
+          simple_format(text)
+          ^^^^^^^^^^^^^^^^^^^ cssで改行反映されるようにしてください。
+        end
+      RUBY
+    end
 
-  it 'rawが使用された場合は警告される' do
-    expect_offense(<<~RUBY)
-      def some_method
-        raw(html_content)
-        ^^^^^^^^^^^^^^^^^ sanitizeメソッドを使用してください。
-      end
-    RUBY
-  end
+    it 'rawが使用された場合は警告される' do
+      expect_offense(<<~RUBY)
+        def some_method
+          raw(html_content)
+          ^^^^^^^^^^^^^^^^^ sanitizeメソッドを使用してください。
+        end
+      RUBY
+    end
 
-  it '複数の禁止メソッドが使用された場合は全て警告される' do
-    expect_offense(<<~RUBY)
-      def some_method
-        simple_format(text)
-        ^^^^^^^^^^^^^^^^^^^ cssで改行反映されるようにしてください。
-        raw(html_content)
-        ^^^^^^^^^^^^^^^^^ sanitizeメソッドを使用してください。
-      end
-    RUBY
-  end
+    it '複数の禁止メソッドが使用された場合は全て警告される' do
+      expect_offense(<<~RUBY)
+        def some_method
+          simple_format(text)
+          ^^^^^^^^^^^^^^^^^^^ cssで改行反映されるようにしてください。
+          raw(html_content)
+          ^^^^^^^^^^^^^^^^^ sanitizeメソッドを使用してください。
+        end
+      RUBY
+    end
 
-  it '禁止メソッドがレシーバ付きで呼ばれた場合は警告されない' do
-    expect_no_offenses(<<~RUBY)
-      def some_method
-        helper.simple_format(text)
-        other.raw(html_content)
-      end
-    RUBY
-  end
+    it '禁止メソッドがレシーバ付きで呼ばれた場合は警告されない' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          helper.simple_format(text)
+          other.raw(html_content)
+        end
+      RUBY
+    end
 
-  it '禁止されていないメソッドは警告されない' do
-    expect_no_offenses(<<~RUBY)
-      def some_method
-        sanitize(html_content)
-        content_tag(:p, text)
-      end
-    RUBY
+    it '禁止されていないメソッドは警告されない' do
+      expect_no_offenses(<<~RUBY)
+        def some_method
+          sanitize(html_content)
+          content_tag(:p, text)
+        end
+      RUBY
+    end
   end
 
   context '設定が空の場合' do
-    let(:config) do
-      RuboCop::Config.new(
-        'Sgcop/RestrictedViewHelpers' => {
-          'RestrictedMethods' => {},
-        }
-      )
-    end
+    let(:cop_config) { { 'RestrictedMethods' => {} } }
 
     it '警告が発生しない' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/sgcop/rspec/no_method_call_in_expectation_spec.rb
+++ b/spec/rubocop/cop/sgcop/rspec/no_method_call_in_expectation_spec.rb
@@ -1,197 +1,217 @@
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::Rspec::NoMethodCallInExpectation do
-  subject(:cop) { RuboCop::Cop::Sgcop::Rspec::NoMethodCallInExpectation.new(config) }
-
-  let(:config) do
-    RuboCop::Config.new(
-      'Sgcop/Rspec/NoMethodCallInExpectation' => {
+describe RuboCop::Cop::Sgcop::Rspec::NoMethodCallInExpectation, :config do
+  context 'with default configuration' do
+    let(:cop_config) do
+      {
         'TargetMatchers' => %w[have_content have_text have_css have_selector eq include],
         'AllowedPatterns' => ['^I18n\.t$', '^I18n\.l$'],
       }
-    )
-  end
-
-  context 'when using method calls in have_content' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        expect(page).to have_content(project.title)
-                                     ^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
-      RUBY
-    end
-  end
-
-  context 'when using method calls in have_text' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        expect(page).to have_text(user.name)
-                                  ^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_text" with literal values.
-      RUBY
-    end
-  end
-
-  context 'when using method calls in eq' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        expect(result).to eq(calculate_value())
-                             ^^^^^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "eq" with literal values.
-      RUBY
-    end
-  end
-
-  context 'when using method calls in include' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        expect(array).to include(item.value)
-                                 ^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "include" with literal values.
-      RUBY
-    end
-  end
-
-  context 'when using instance variable method calls' do
-    it 'registers an offense' do
-      expect_offense(<<~RUBY)
-        expect(page).to have_content(@project.title)
-                                     ^^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
-      RUBY
-    end
-  end
-
-  context 'when using local variables' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(result).to eq(expected_value)
-      RUBY
-    end
-  end
-
-  context 'when using instance variables' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content(@project)
-      RUBY
-    end
-  end
-
-  context 'when using constants' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content(PROJECT_TITLE)
-      RUBY
-    end
-  end
-
-  context 'when using literal string' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content("プロジェクトタイトル")
-      RUBY
-    end
-  end
-
-  context 'when using literal number' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(count).to eq(5)
-      RUBY
-    end
-  end
-
-  context 'when using literal symbol' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(status).to eq(:success)
-      RUBY
-    end
-  end
-
-  context 'when using literal boolean' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(result).to eq(true)
-        expect(flag).to eq(false)
-      RUBY
-    end
-  end
-
-  context 'when using nil' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(value).to eq(nil)
-      RUBY
-    end
-  end
-
-  context 'when using literal array' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(items).to eq(["item1", "item2"])
-      RUBY
-    end
-  end
-
-  context 'when using array with variables' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(items).to eq([item1, item2, @item3])
-      RUBY
-    end
-  end
-
-  context 'when using literal hash' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(data).to eq({ name: "Test", value: 123 })
-      RUBY
-    end
-  end
-
-  context 'when using hash with variables' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(data).to eq({ name: username, value: count })
-      RUBY
-    end
-  end
-
-  context 'when using regexp' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(text).to match(/pattern/)
-      RUBY
-    end
-  end
-
-  context 'when using I18n.t' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content(I18n.t('projects.title'))
-      RUBY
     end
 
-    it 'does not register an offense with have_selector text option' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_selector 'h1', text: I18n.t('text.title')
-      RUBY
+    context 'when using method calls in have_content' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          expect(page).to have_content(project.title)
+                                       ^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
+        RUBY
+      end
     end
-  end
 
-  context 'when using I18n.l' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content(I18n.l(date))
-      RUBY
+    context 'when using method calls in have_text' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          expect(page).to have_text(user.name)
+                                    ^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_text" with literal values.
+        RUBY
+      end
+    end
+
+    context 'when using method calls in eq' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          expect(result).to eq(calculate_value())
+                               ^^^^^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "eq" with literal values.
+        RUBY
+      end
+    end
+
+    context 'when using method calls in include' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          expect(array).to include(item.value)
+                                   ^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "include" with literal values.
+        RUBY
+      end
+    end
+
+    context 'when using instance variable method calls' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          expect(page).to have_content(@project.title)
+                                       ^^^^^^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
+        RUBY
+      end
+    end
+
+    context 'when using local variables' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(result).to eq(expected_value)
+        RUBY
+      end
+    end
+
+    context 'when using instance variables' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content(@project)
+        RUBY
+      end
+    end
+
+    context 'when using constants' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content(PROJECT_TITLE)
+        RUBY
+      end
+    end
+
+    context 'when using literal string' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content("プロジェクトタイトル")
+        RUBY
+      end
+    end
+
+    context 'when using literal number' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(count).to eq(5)
+        RUBY
+      end
+    end
+
+    context 'when using literal symbol' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(status).to eq(:success)
+        RUBY
+      end
+    end
+
+    context 'when using literal boolean' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(result).to eq(true)
+          expect(flag).to eq(false)
+        RUBY
+      end
+    end
+
+    context 'when using nil' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(value).to eq(nil)
+        RUBY
+      end
+    end
+
+    context 'when using literal array' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(items).to eq(["item1", "item2"])
+        RUBY
+      end
+    end
+
+    context 'when using array with variables' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(items).to eq([item1, item2, @item3])
+        RUBY
+      end
+    end
+
+    context 'when using literal hash' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(data).to eq({ name: "Test", value: 123 })
+        RUBY
+      end
+    end
+
+    context 'when using hash with variables' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(data).to eq({ name: username, value: count })
+        RUBY
+      end
+    end
+
+    context 'when using regexp' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(text).to match(/pattern/)
+        RUBY
+      end
+    end
+
+    context 'when using I18n.t' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content(I18n.t('projects.title'))
+        RUBY
+      end
+
+      it 'does not register an offense with have_selector text option' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_selector 'h1', text: I18n.t('text.title')
+        RUBY
+      end
+    end
+
+    context 'when using I18n.l' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content(I18n.l(date))
+        RUBY
+      end
+    end
+
+    context 'when using non-configured matcher' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          expect(result).to be_truthy
+          expect(page).to have_link(link.text)
+        RUBY
+      end
+    end
+
+    context 'when using multiple arguments' do
+      it 'registers offenses for method call arguments only' do
+        expect_offense(<<~RUBY)
+          expect(page).to have_content("Fixed Text", user.name)
+                                                     ^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
+        RUBY
+      end
+
+      it 'does not register offenses for variable arguments' do
+        expect_no_offenses(<<~RUBY)
+          expect(page).to have_content("Fixed Text", dynamic_text)
+        RUBY
+      end
     end
   end
 
   context 'when using URL helpers' do
-    let(:config) do
-      RuboCop::Config.new(
-        'Sgcop/Rspec/NoMethodCallInExpectation' => {
-          'TargetMatchers' => %w[have_content eq have_selector],
-          'AllowedPatterns' => ['_path$', '_url$'],
-        }
-      )
+    let(:cop_config) do
+      {
+        'TargetMatchers' => %w[have_content eq have_selector],
+        'AllowedPatterns' => ['_path$', '_url$'],
+      }
     end
 
     it 'does not register an offense for _path helpers' do
@@ -234,38 +254,12 @@ describe RuboCop::Cop::Sgcop::Rspec::NoMethodCallInExpectation do
     end
   end
 
-  context 'when using non-configured matcher' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        expect(result).to be_truthy
-        expect(page).to have_link(link.text)
-      RUBY
-    end
-  end
-
-  context 'when using multiple arguments' do
-    it 'registers offenses for method call arguments only' do
-      expect_offense(<<~RUBY)
-        expect(page).to have_content("Fixed Text", user.name)
-                                                   ^^^^^^^^^ Use literal values instead of method calls in expectations. Use "have_content" with literal values.
-      RUBY
-    end
-
-    it 'does not register offenses for variable arguments' do
-      expect_no_offenses(<<~RUBY)
-        expect(page).to have_content("Fixed Text", dynamic_text)
-      RUBY
-    end
-  end
-
   context 'when custom configuration' do
-    let(:config) do
-      RuboCop::Config.new(
-        'Sgcop/Rspec/NoMethodCallInExpectation' => {
-          'TargetMatchers' => %w[eq],
-          'AllowedPatterns' => ['^helper_method$'],
-        }
-      )
+    let(:cop_config) do
+      {
+        'TargetMatchers' => %w[eq],
+        'AllowedPatterns' => ['^helper_method$'],
+      }
     end
 
     it 'only checks configured matchers' do

--- a/spec/rubocop/cop/sgcop/strftime_restriction_spec.rb
+++ b/spec/rubocop/cop/sgcop/strftime_restriction_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
 
-describe RuboCop::Cop::Sgcop::StrftimeRestriction do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new(cop_config) }
-  let(:cop_config) { { 'Sgcop/StrftimeRestriction' => {} } }
-
+describe RuboCop::Cop::Sgcop::StrftimeRestriction, :config do
   context '指定子と区切り記号のみで構成される場合は許容される' do
     it 'ハイフン区切り（%Y-%m-%d）は警告されない' do
       expect_no_offenses(<<~RUBY)
@@ -188,7 +183,7 @@ describe RuboCop::Cop::Sgcop::StrftimeRestriction do
   end
 
   context 'AllowedPatternsに完全一致を指定した場合（後方互換）' do
-    let(:cop_config) { { 'Sgcop/StrftimeRestriction' => { 'AllowedPatterns' => ['%Y年%m月%d日'] } } }
+    let(:cop_config) { { 'AllowedPatterns' => ['%Y年%m月%d日'] } }
 
     it '完全一致するリテラル入りフォーマットは警告されない' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
## Summary
- 各 cop spec が子 context で親の let/subject を上書きしており `Sgcop/Rspec/NoLetOverride` 違反になっていたのを解消
- rubocop-rspec の `:config` shared_context（既に一部 spec で採用済み）に統一し、`subject(:cop)` や `RuboCop::Config.new` の手書きボイラープレートを排除
- 各 context は `let(:cop_config)` の差し替えだけで設定を切り替えられる形にし、default 設定のテスト群は不要なラッピング context を持たずトップレベル直下のまま維持

## Test plan
- [x] `bundle exec rubocop` で違反ゼロを確認
- [x] `bundle exec rspec` で全テストがパスすることを確認