### PR TITLE
fix: rubocop.ymlのExclude設定をmerge継承に変更

### DIFF
--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -15,6 +15,9 @@ require:
 
 # 自動生成されるものなどはチェック対象から除外する
 AllCops:
+  inherit_mode:
+    merge:
+      - Exclude
   Exclude:
     - "bin/*"
     - "config/backup.rb"
@@ -25,7 +28,6 @@ AllCops:
     - "config.ru"
     - "db/*schema.rb"
     - "deploy/*"
-    - "node_modules/**/*"
     - "spec/rails_helper.rb"
     - "spec/spec_helper.rb"
     - "vendor/**/*"

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
   DisplayStyleGuide: true
   StyleGuideBaseURL: https://github.com/fortissimo1997/ruby-style-guide/blob/japanese/README.ja.md
   ExtraDetails: true
+  Exclude:
+    - "apm_modules/**/*"
+    - "node_modules/**/*"
+    - ".claude/**/*"
 
 # ============================================================
 # Style


### PR DESCRIPTION
## Summary
- rails/rubocop.yml に `inherit_mode.merge: [Exclude]` を追加し、ruby/rubocop.yml から継承する Exclude 設定を上書きせずマージするように変更
- ruby/rubocop.yml に AllCops.Exclude を新設（apm_modules, node_modules, .claude）し、除外対象を継承元に一元化
- rails/rubocop.yml から重複した node_modules の除外を削除

## Test plan
- [ ] rails/rubocop.yml を利用するプロジェクトで rubocop 実行時に node_modules/apm_modules/.claude が除外されることを確認