### PR TITLE
chore: Layout/LineLengthのAllowedPatternsにsvgタグを追加

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -704,6 +704,7 @@ Layout/LineLength:
   Max: 160
   AllowedPatterns:
     - "^ *#"
+    - "<svg"
 
 # 複数行に渡る Hash では、一行に複数のキーを入れてはならない
 # https://docs.rubocop.org/rubocop/latest/cops_layout.html#layoutmultilinehashkeylinebreaks


### PR DESCRIPTION
## Summary
- `Layout/LineLength` の `AllowedPatterns` に `<svg` を追加し、SVGタグを含む行を行長チェックの対象外にする