### PR TITLE
[review] fix: Sgcop/HashFetchDefaultで複数キーのフォールバックを対象外に

### DIFF
--- a/lib/rubocop/cop/sgcop/hash_fetch_default.rb
+++ b/lib/rubocop/cop/sgcop/hash_fetch_default.rb
@@ -17,12 +17,31 @@ module RuboCop
           left_node = node.lhs
           return unless hash_element_access(left_node)
 
+          # 同一ハッシュの複数キーへのフォールバック（`a[:x] || a[:y]`）は
+          # falsey 値保持の意図ではないため対象外とする。
+          # rhs がハッシュアクセスでない場合や、レシーバが異なる場合（`a[:x] || b[:y]`）は
+          # falsey 値保持のパターンなので検出する。
+          # なお、rhs 自体がさらに or チェーンを含む場合（`a[:x] || b || a[:z]` 等）でも、
+          # ここでは node の直接の rhs だけを見て判定し、その先のチェーンは覗き見ない。
+          return if same_hash_fallback?(left_node, node.rhs)
+
           add_offense(node) do |corrector|
             hash_obj, key = hash_element_access(left_node)
             default_value = node.rhs
 
             corrector.replace(node, "#{hash_obj.source}.fetch(#{key.source}, #{default_value.source})")
           end
+        end
+
+        private
+
+        # left_node（`left_node || rhs` の lhs）と rhs が、同一レシーバへの
+        # 2項のハッシュアクセスフォールバックかどうかを判定する。
+        def same_hash_fallback?(left_node, rhs)
+          receiver, = hash_element_access(left_node)
+          other_receiver, = hash_element_access(rhs)
+
+          !other_receiver.nil? && other_receiver == receiver
         end
       end
     end

--- a/spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb
+++ b/spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb
@@ -94,4 +94,88 @@ describe RuboCop::Cop::Sgcop::HashFetchDefault do
       obj[key_method] || "default"
     RUBY
   end
+
+  it 'does not register an offense for a multi-key fallback chain' do
+    expect_no_offenses(<<~RUBY)
+      media_box = page[:CropBox] || page[:MediaBox] || [0, 0, 595.3, 841.9]
+    RUBY
+  end
+
+  it 'does not register an offense for a two-element hash access chain' do
+    expect_no_offenses(<<~RUBY)
+      a[:x] || a[:y]
+    RUBY
+  end
+
+  it 'does not register an offense for a four-element fallback chain' do
+    expect_no_offenses(<<~RUBY)
+      a[:x] || a[:y] || a[:z] || 1
+    RUBY
+  end
+
+  it 'registers an offense when rhs is not a hash access' do
+    expect_offense(<<~RUBY)
+      a[:x] || b.foo
+      ^^^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a.fetch(:x, b.foo)
+    RUBY
+  end
+
+  it 'registers an offense when rhs is a hash access on a different receiver' do
+    expect_offense(<<~RUBY)
+      a[:x] || b[:y]
+      ^^^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a.fetch(:x, b[:y])
+    RUBY
+  end
+
+  it 'registers an offense for the inner or of a chain whose rhs is not a hash access' do
+    expect_offense(<<~RUBY)
+      config[:timeout] || DEFAULT_TIMEOUT || 30
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      config.fetch(:timeout, DEFAULT_TIMEOUT) || 30
+    RUBY
+  end
+
+  it 'registers an offense when the or is on the rhs of an outer or' do
+    expect_offense(<<~RUBY)
+      foo or a[:x] || bar
+             ^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      foo or a.fetch(:x, bar)
+    RUBY
+  end
+
+  it 'registers an offense for the inner or when the outer rhs is a same-receiver hash access but the inner rhs is not' do
+    expect_offense(<<~RUBY)
+      a[:x] || compute_default || a[:z]
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a.fetch(:x, compute_default) || a[:z]
+    RUBY
+  end
+
+  it 'registers an offense for the inner or when the inner rhs is a different-receiver hash access' do
+    expect_offense(<<~RUBY)
+      a[:x] || b[:y] || a[:z]
+      ^^^^^^^^^^^^^^ Sgcop/HashFetchDefault: Use `Hash#fetch` with a default value instead of `||` to preserve falsey values.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      a.fetch(:x, b[:y]) || a[:z]
+    RUBY
+  end
 end


### PR DESCRIPTION
## Summary
- `hash[:x] || hash[:y] || default` のような同一ハッシュへの複数キーフォールバックを `Sgcop/HashFetchDefault` の検出対象から除外
- 従来はこのパターンも `hash.fetch(:x, hash[:y])` に autocorrect され、短絡評価が失われて意味が壊れていた（`hash[:x]` が `false` のとき `hash[:y]` が無視される）
- 除外は「rhs が同一レシーバへのハッシュアクセス」の場合のみ。レシーバが異なる場合（`a[:x] || b[:y]`）や rhs がハッシュアクセスでない場合は引き続き検出・補正する

## Test plan
- [x] `bundle exec rspec spec/rubocop/cop/sgcop/hash_fetch_default_spec.rb`（21 examples, 0 failures）
- [x] `bundle exec rspec`（446 examples, 0 failures）
- [x] `bundle exec rubocop`（90 files inspected, no offenses detected）